### PR TITLE
fix: clear focused preview when suggestions are hidden

### DIFF
--- a/lib/code_forge/code_area.dart
+++ b/lib/code_forge/code_area.dart
@@ -1506,7 +1506,7 @@ class _CodeForgeState extends State<CodeForge>
                   valueListenable: _suggestionNotifier,
                   builder: (_, sugg, child) {
                     if (_aiNotifier.value != null) return SizedBox.shrink();
-                    if (sugg == null) {
+                    if (sugg == null || sugg.isEmpty) {
                       _sugSelIndex = 0;
                       return SizedBox.shrink();
                     }


### PR DESCRIPTION
Bug (Example js)
- Type `le` → suggestions appear, `let` is focused and preview is shown
- Type `let ` → suggestions and preview are hidden
- Type `let s` → suggestions stay hidden but `let` preview incorrectly reappears