### PR TITLE
Fix Flutter 3.44 text input client compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- FIX: Added Flutter 3.44 compatibility for `TextInputClient.onFocusReceived`.
+
 ## 1.0.0
 
 <details>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -227,10 +227,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: "direct main"
     description:
@@ -368,10 +368,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/lib/code_forge/controller.dart
+++ b/lib/code_forge/controller.dart
@@ -2737,6 +2737,10 @@ class CodeForgeController implements DeltaTextInputClient {
 
   @protected
   @override
+  bool onFocusReceived() => false;
+
+  @protected
+  @override
   void showToolbar() {}
 
   @protected


### PR DESCRIPTION
## Summary
- Implement TextInputClient.onFocusReceived in CodeForgeController for Flutter 3.44 compatibility.
- Return false to keep the same conservative/default focus behavior.
- Refresh the example lockfile after resolving dependencies with Flutter 3.44.

## Verification
- flutter pub get
- flutter analyze --no-pub
- flutter test --no-pub (expected: Test directory "test" not found)
- (cd example && flutter test --no-pub) (expected: Test directory "test" not found)