### PR TITLE
Fix CJK IME composition garbling and undo grouping

### DIFF
--- a/lib/code_forge/controller.dart
+++ b/lib/code_forge/controller.dart
@@ -61,6 +61,10 @@ class CodeForgeController implements DeltaTextInputClient {
   TextSelection _imeProjectionSelection = const TextSelection.collapsed(
     offset: 0,
   );
+  TextRange _imeComposingGlobal = TextRange.empty;
+  TextRange _imeProjectionComposing = TextRange.empty;
+  bool _suppressImeSync = false;
+  CompoundOperationHandle? _imeCompositionUndoGroup;
   bool _bufferDirty = false, bufferNeedsRepaint = false, selectionOnly = false;
   bool _imeProjectionDirty = true, _imeSelectionNeedsResync = false;
   bool deleteFoldRangeOnDeletingFirstLine = false;
@@ -2349,6 +2353,12 @@ class CodeForgeController implements DeltaTextInputClient {
     _ensureImeProjection();
     bool typingDetected = false;
 
+    _suppressImeSync = true;
+    _beginImeCompositionUndoGroup(
+      textEditingDeltas.any(
+        (d) => d.composing.isValid && !d.composing.isCollapsed,
+      ),
+    );
     for (final delta in textEditingDeltas) {
       if (delta is TextEditingDeltaNonTextUpdate) {
         if (_lastSentSelection == null ||
@@ -2357,6 +2367,12 @@ class CodeForgeController implements DeltaTextInputClient {
         }
         _lastSentSelection = null;
         _imeSelectionNeedsResync = false;
+        _trackImeComposing(
+          delta.composing,
+          delta.selection.isValid
+              ? delta.selection.extentOffset
+              : delta.composing.end,
+        );
         continue;
       }
 
@@ -2434,9 +2450,20 @@ class CodeForgeController implements DeltaTextInputClient {
           _localImeSelectionToGlobal(delta.selection),
         );
       }
+
+      _trackImeComposing(
+        delta.composing,
+        delta.selection.isValid
+            ? delta.selection.extentOffset
+            : delta.composing.end,
+      );
     }
+    _endImeCompositionUndoGroupIfIdle();
+    _suppressImeSync = false;
 
     _isTyping = typingDetected;
+
+    _imeProjectionDirty = true;
 
     notifyListeners();
   }
@@ -2507,6 +2534,10 @@ class CodeForgeController implements DeltaTextInputClient {
   }
 
   void _syncToConnection() {
+    if (_suppressImeSync) return;
+    if (_imeComposingGlobal.isValid && !_imeComposingGlobal.isCollapsed) {
+      return;
+    }
     if (connection != null && connection!.attached) {
       _ensureImeProjection();
       _lastSentSelection = _imeProjectionSelection;
@@ -2514,6 +2545,7 @@ class CodeForgeController implements DeltaTextInputClient {
         TextEditingValue(
           text: _imeProjectionText,
           selection: _imeProjectionSelection,
+          composing: _imeProjectionComposing,
         ),
       );
     }
@@ -2603,6 +2635,7 @@ class CodeForgeController implements DeltaTextInputClient {
       _imeProjectionStartOffset = 0;
       _imeProjectionText = '';
       _imeProjectionSelection = const TextSelection.collapsed(offset: 0);
+      _imeProjectionComposing = TextRange.empty;
       _imeProjectionDirty = false;
       return;
     }
@@ -2667,6 +2700,10 @@ class CodeForgeController implements DeltaTextInputClient {
       baseOffset: localBase,
       extentOffset: localExtent,
     );
+    _imeProjectionComposing = _projectComposing(
+      projectionStartOffset,
+      projectionText.length,
+    );
     _imeProjectionDirty = false;
   }
 
@@ -2674,7 +2711,7 @@ class CodeForgeController implements DeltaTextInputClient {
     _ensureImeProjection();
     final result = (_imeProjectionStartOffset + localOffset).clamp(
       0,
-      _rope.length,
+      length,
     );
     return result;
   }
@@ -2684,6 +2721,74 @@ class CodeForgeController implements DeltaTextInputClient {
       baseOffset: _localImeOffsetToGlobal(localSelection.baseOffset),
       extentOffset: _localImeOffsetToGlobal(localSelection.extentOffset),
     );
+  }
+
+  /// Maps the tracked global composing region into the active IME projection
+  /// window's local coordinate space, clamped to the projected text.
+  ///
+  /// Returns [TextRange.empty] when there is no active composition or when the
+  /// region lies entirely outside the projected window (and therefore cannot be
+  /// represented to the platform faithfully).
+  TextRange _projectComposing(int projectionStartOffset, int projectionLength) {
+    final composing = _imeComposingGlobal;
+    if (!composing.isValid || composing.isCollapsed) return TextRange.empty;
+    final localStart = composing.start - projectionStartOffset;
+    final localEnd = composing.end - projectionStartOffset;
+    if (localEnd <= 0 || localStart >= projectionLength) return TextRange.empty;
+    final clampedStart = localStart.clamp(0, projectionLength);
+    final clampedEnd = localEnd.clamp(0, projectionLength);
+    if (clampedStart >= clampedEnd) return TextRange.empty;
+    return TextRange(start: clampedStart, end: clampedEnd);
+  }
+
+  /// Records the IME composing region (reported in the projection's local
+  /// coordinates) as a stable global-document range.
+  ///
+  /// The region is anchored to the editor's *actual* post-edit caret rather
+  /// than to the IME's raw offset, so it stays correct even when an insertion
+  /// is re-anchored to the current selection (see [updateEditingValueWithDeltas]
+  /// and its `useCurrentSelection` path) or while typed characters are still
+  /// held in the line buffer.
+  void _trackImeComposing(TextRange imeComposing, int imeCaretLocal) {
+    if (!imeComposing.isValid || imeComposing.isCollapsed) {
+      _imeComposingGlobal = TextRange.empty;
+      return;
+    }
+    final caretGlobal = _selection.extentOffset;
+    final caretWithin = imeCaretLocal - imeComposing.start;
+    final startGlobal = caretGlobal - caretWithin;
+    final composingLength = imeComposing.end - imeComposing.start;
+    final docLength = length;
+    final start = startGlobal.clamp(0, docLength);
+    final end = (startGlobal + composingLength).clamp(0, docLength);
+    _imeComposingGlobal = start < end
+        ? TextRange(start: start, end: end)
+        : TextRange.empty;
+  }
+
+  /// Opens a single undo group spanning an entire IME composition so the
+  /// intermediate composing edits (e.g. the raw pinyin letters) collapse into
+  /// one undoable unit together with the final committed text.
+  ///
+  /// A composition is reported across multiple input callbacks, so the group
+  /// is opened on the first callback that carries a composing region and is
+  /// kept open (see [_imeCompositionUndoGroup]) until the composition ends.
+  /// Must be called before the edit for the current callback is recorded.
+  void _beginImeCompositionUndoGroup(bool incomingHasComposing) {
+    if (incomingHasComposing && _imeCompositionUndoGroup == null) {
+      _imeCompositionUndoGroup = _undoController?.beginCompoundOperation();
+    }
+  }
+
+  /// Closes the composition undo group once the composition is no longer
+  /// active, merging everything recorded since it was opened into a single
+  /// undo entry. Safe to call when no group is open.
+  void _endImeCompositionUndoGroupIfIdle() {
+    if (_imeCompositionUndoGroup != null &&
+        (!_imeComposingGlobal.isValid || _imeComposingGlobal.isCollapsed)) {
+      _imeCompositionUndoGroup!.end();
+      _imeCompositionUndoGroup = null;
+    }
   }
 
   /// Remove the selection or last char if the selection is empty (backspace key)
@@ -3092,6 +3197,9 @@ class CodeForgeController implements DeltaTextInputClient {
       connection = null;
       focusNode?.unfocus();
     }
+    _imeComposingGlobal = TextRange.empty;
+    _imeCompositionUndoGroup?.end();
+    _imeCompositionUndoGroup = null;
   }
 
   @protected
@@ -3108,6 +3216,7 @@ class CodeForgeController implements DeltaTextInputClient {
     return TextEditingValue(
       text: _imeProjectionText,
       selection: _imeProjectionSelection,
+      composing: _imeProjectionComposing,
     );
   }
 
@@ -3155,7 +3264,11 @@ class CodeForgeController implements DeltaTextInputClient {
   void updateEditingValue(TextEditingValue value) {
     if (readOnly) return;
 
+    _suppressImeSync = true;
     _ensureImeProjection();
+    _beginImeCompositionUndoGroup(
+      value.composing.isValid && !value.composing.isCollapsed,
+    );
 
     final currentText = _imeProjectionText;
     final nextText = value.text;
@@ -3196,6 +3309,14 @@ class CodeForgeController implements DeltaTextInputClient {
     _imeProjectionDirty = true;
     dirtyRegion = TextRange(start: 0, end: _rope.length);
     dirtyLine = null;
+    _trackImeComposing(
+      value.composing,
+      value.selection.isValid
+          ? value.selection.extentOffset
+          : value.composing.end,
+    );
+    _endImeCompositionUndoGroupIfIdle();
+    _suppressImeSync = false;
     notifyListeners();
   }
 
@@ -3246,6 +3367,7 @@ class CodeForgeController implements DeltaTextInputClient {
   }) {
     if (_undoController?.isUndoRedoInProgress ?? false) return;
 
+    if (!_suppressImeSync) _imeComposingGlobal = TextRange.empty;
     final selectionBefore = _selection;
     _flushBuffer();
     final safeStart = start.clamp(0, _rope.length);

--- a/lib/code_forge/undo_redo.dart
+++ b/lib/code_forge/undo_redo.dart
@@ -247,6 +247,12 @@ class UndoRedoController extends ChangeNotifier {
   /// Whether an undo/redo operation is currently in progress
   bool _isUndoRedoInProgress = false;
 
+  /// When set, the next recorded edit will not be merged into the previous
+  /// one. Used so that the first edit inside a compound operation never merges
+  /// into an edit recorded before the compound began (which would let it
+  /// escape the group).
+  bool _suppressNextMerge = false;
+
   UndoRedoController({this.maxStackSize = 1000, this.groupEdits = true});
 
   /// Whether undo is available
@@ -277,14 +283,16 @@ class UndoRedoController extends ChangeNotifier {
       _redoStack.clear();
     }
 
-    if (groupEdits && _undoStack.isNotEmpty) {
+    if (groupEdits && _undoStack.isNotEmpty && !_suppressNextMerge) {
       final last = _undoStack.last;
       if (last.canMergeWith(operation)) {
         _undoStack[_undoStack.length - 1] = last.mergeWith(operation);
+        _suppressNextMerge = false;
         notifyListeners();
         return;
       }
     }
+    _suppressNextMerge = false;
 
     _undoStack.add(operation);
 
@@ -342,6 +350,7 @@ class UndoRedoController extends ChangeNotifier {
   /// Begin a compound operation that should be undone as a single unit.
   /// Call [endCompoundOperation] when done.
   CompoundOperationHandle beginCompoundOperation() {
+    _suppressNextMerge = true;
     return CompoundOperationHandle._(this);
   }
 


### PR DESCRIPTION
## Summary

CJK input via an IME was garbled in the editor on Windows desktop. Typing
pinyin such as `hao'jia'huo` produced an accumulating string
(`hhahaohao'jhao'ji...好家伙`) where every composition update re-inserted
the growing composing text instead of replacing the previous one; the
correct characters only appeared once committed. This PR fixes the
composition handling and a related undo bug.

## Root cause

Flutter's delta input model (`updateEditingValueWithDeltas`) is only wired
up on mobile and web. On Windows desktop, IME composition comes through the
full-value `TextInputClient.updateEditingValue` path (flutter/flutter#107462).
The editor pushed editing state back to the IME on every keystroke
(`replaceRange` -> `_invalidateImeSnapshotAndScheduleSync` ->
`_syncToConnection`), and that value carried no composing region. Windows
interprets a state with no composing region mid-composition as the
composition ending, so the next keystroke started a new composition and the
whole pinyin string was re-inserted. ASCII was unaffected because it has no
composition to interrupt.

## Changes

- The editor no longer echoes editing state back to the connection while an
  edit is driven by the IME or while a composition is active.
  `_syncToConnection` is suppressed during `updateEditingValue` /
  `updateEditingValueWithDeltas` and short-circuits whenever a composition is
  in progress (this also covers the debounced async sync). State is still
  pushed on editor-initiated changes.
- The composing region is tracked in document coordinates, anchored to the
  actual post-edit caret, and reported back in the editing value.
- Undo: a whole composition is grouped into a single compound undo
  operation, so one undo after committing removes the committed text instead
  of exposing the raw pinyin. `beginCompoundOperation` also breaks the merge
  chain so the first edit in a group cannot merge into an edit recorded just
  before the group began (this also makes existing multi-cursor compound
  edits group correctly).

## Testing

Verified manually on Windows desktop with the Microsoft Pinyin IME:
- Typing `haojiahuo` and committing produces `好家伙` with no garbling.
- A single undo after committing removes `好家伙` and does not reveal the
  intermediate pinyin; redo restores it.
- ASCII typing, selection, paste, and undo/redo are unaffected.

The same handling is applied to the delta path used by mobile/web, but those
platforms have not been tested.

## Files

- `lib/code_forge/controller.dart` — composition handling and undo grouping.
- `lib/code_forge/undo_redo.dart` — break the merge chain when a compound
  operation begins.