### PR TITLE
fix(ime): stabilize cross-platform composition handling

### DIFF
--- a/lib/code_forge/code_area.dart
+++ b/lib/code_forge/code_area.dart
@@ -26,7 +26,19 @@ import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:vector_math/vector_math_64.dart' show Vector3;
 
 const int kSemanticTokenViewportPaddingLines = 1500;
-const String _wordCharPattern = r'[\w\u0600-\u06FF\u08A0-\u08FF\u0590-\u05FF]';
+// Characters treated as part of a "word" for double-click selection, word-prefix
+// extraction, and hover. Covers Latin/digits/underscore (\w), Arabic and Hebrew,
+// and CJK: Hiragana (3040-309F), Katakana (30A0-30FF), CJK Extension A
+// (3400-4DBF), CJK Unified Ideographs (4E00-9FFF), Hangul Syllables (AC00-D7AF),
+// and CJK Compatibility Ideographs (F900-FAFF). Without the CJK ranges every CJK
+// glyph counts as a word boundary, so double-clicking Chinese/Japanese/Korean
+// text selects nothing; including them makes a double-click select the
+// contiguous CJK run, mirroring how it selects a run of Latin letters. CJK
+// punctuation/symbol blocks are intentionally excluded so they remain
+// boundaries, like ASCII punctuation.
+const String _wordCharPattern =
+    r'[\w\u0600-\u06FF\u08A0-\u08FF\u0590-\u05FF'
+    r'\u3040-\u309F\u30A0-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF]';
 
 /// A highly customizable code editor widget for Flutter.
 ///
@@ -556,30 +568,32 @@ class _CodeForgeState extends State<CodeForge> with TickerProviderStateMixin {
     _focusNode.addListener(() {
       if (_focusNode.hasFocus && !_readOnly) {
         if (_connection == null || !_connection!.attached) {
-          _connection = TextInput.attach(
-            _controller,
-            TextInputConfiguration(
-              readOnly: widget.readOnly,
-              enableDeltaModel: true,
-              enableSuggestions: widget.enableKeyboardSuggestions,
-              inputType: widget.keyboardType,
-              inputAction: TextInputAction.newline,
-              autocorrect: false,
-              viewId: View.of(context).viewId,
-            ),
-          );
+          _connection = _attachImeConnection();
 
           _controller.connection = _connection;
-          _connection!.show();
-          _connection!.setEditingState(
-            TextEditingValue(
-              text: _controller.text,
-              selection: _controller.selection,
-            ),
-          );
         }
+        // Always (re)activate the platform IME when focus is gained, even if a
+        // connection was already attached before focus (see the post-frame path
+        // below). Without show() the desktop IME never becomes the active input
+        // client: on macOS this blocks text input entirely, and on Windows it
+        // leaves the editor able to highlight lines but unable to accept typing.
+        _connection!.show();
+        // Seed the platform with the IME projection (the small window around the
+        // caret) rather than the full document. The controller's input handlers
+        // operate in projection coordinates, so seeding the full text leaves the
+        // two out of sync and makes the first typed/composed characters land far
+        // from the caret (e.g. on a line above where the user clicked).
+        _connection!.setEditingState(
+          _controller.currentTextEditingValue ??
+              TextEditingValue(
+                text: _controller.text,
+                selection: _controller.selection,
+              ),
+        );
       }
     });
+
+    _controller.requestImeReset = _resetImeConnection;
 
     Future.microtask(CustomIcons.loadAllCustomFonts);
 
@@ -750,26 +764,64 @@ class _CodeForgeState extends State<CodeForge> with TickerProviderStateMixin {
       if (widget.autoFocus) {
         _focusNode.requestFocus();
       } else {
-        _connection = TextInput.attach(
-          _controller,
-          TextInputConfiguration(
-            readOnly: widget.readOnly,
-            enableDeltaModel: true,
-            enableSuggestions: widget.enableKeyboardSuggestions,
-            inputType: widget.keyboardType,
-            inputAction: TextInputAction.newline,
-            autocorrect: false,
-            viewId: View.of(context).viewId,
-          ),
-        );
+        _connection = _attachImeConnection();
 
-        _connection!.setEditingState(TextEditingValue(text: _controller.text));
+        _connection!.setEditingState(
+          _controller.currentTextEditingValue ??
+              TextEditingValue(text: _controller.text),
+        );
 
         if (_isMobile) _focusNode.requestFocus();
 
         _controller.connection = _connection;
       }
     });
+  }
+
+  /// Attaches a platform text-input connection configured for this editor.
+  /// Shared by the initial attach, the focus-gain re-attach, and the IME reset
+  /// that drops an in-progress composition so the OS closes its candidate
+  /// window.
+  TextInputConnection _attachImeConnection() {
+    return TextInput.attach(
+      _controller,
+      TextInputConfiguration(
+        readOnly: widget.readOnly,
+        enableDeltaModel: true,
+        enableSuggestions: widget.enableKeyboardSuggestions,
+        inputType: widget.keyboardType,
+        inputAction: TextInputAction.newline,
+        autocorrect: false,
+        viewId: View.of(context).viewId,
+      ),
+    );
+  }
+
+  /// Closes and re-attaches the platform input connection. On desktop this is
+  /// the only reliable way to make the IME abandon an in-progress composition
+  /// and close its candidate window -- pushing an empty composing range via
+  /// setEditingState does not. The document already holds the composed
+  /// characters, so they stay committed; only the platform-side composition
+  /// session is dropped. Wired to [CodeForgeController.requestImeReset].
+  void _resetImeConnection() {
+    if (_readOnly || !_focusNode.hasFocus) return;
+    final previous = _connection;
+    _connection = null;
+    _controller.connection = null;
+    try {
+      previous?.close();
+    } catch (_) {}
+    final fresh = _attachImeConnection();
+    _connection = fresh;
+    _controller.connection = fresh;
+    fresh.show();
+    fresh.setEditingState(
+      _controller.currentTextEditingValue ??
+          TextEditingValue(
+            text: _controller.text,
+            selection: _controller.selection,
+          ),
+    );
   }
 
   void _updateScrollbarLineNumberIndicator() {
@@ -1631,6 +1683,15 @@ class _CodeForgeState extends State<CodeForge> with TickerProviderStateMixin {
                                             return Focus(
                                               focusNode: _focusNode,
                                               onKeyEvent: (node, event) {
+                                                // While an IME composition is in progress (e.g. CJK
+                                                // pinyin), the platform input method owns the keyboard.
+                                                // Defer every key to it: also handling Backspace, arrows,
+                                                // Enter, etc. here would edit the document a second time
+                                                // and desync from the IME (e.g. a backspaced letter
+                                                // reappearing).
+                                                if (_controller.isComposingActive) {
+                                                  return KeyEventResult.ignored;
+                                                }
                                                 final isCtrlAltPressed =
                                                     (HardwareKeyboard
                                                             .instance
@@ -4104,6 +4165,15 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
   CodeSelectionStyle _selectionStyle;
   List<LspErrors> _diagnostics;
   int _cachedCaretOffset = -1, _cachedCaretLine = 0, _cachedCaretLineStart = 0;
+  Rect? _lastImeCaretRect;
+  Rect? _lastImeComposingRect;
+  Size? _lastImeEditableSize;
+  // Set by [_drawImeComposition] each paint: the composing caret offset and the
+  // composing string width, both in line-local content coordinates relative to
+  // the composing anchor. Consumed by [_updateImeGeometry] so the OS candidate
+  // window tracks the composition rather than the (frozen) document caret.
+  double _imeComposingCaretDx = 0.0;
+  double _imeComposingWidth = 0.0;
   int? _dragStartOffset;
   Timer? _selectionTimer, _hoverTimer;
   Offset? _pointerDownPosition;
@@ -5141,6 +5211,29 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
       return;
     }
 
+    if (controller.imeCompositionChanged) {
+      controller.imeCompositionChanged = false;
+      // The composing caret/anchor may have moved, so its cached geometry is
+      // stale.
+      _caretInfoCache.clear();
+      if (!_isFoldToggleInProgress) {
+        _ensureCaretVisible();
+      }
+      if (controller.contentVersion == _lastProcessedContentVersion) {
+        // Pure overlay change (e.g. more pinyin letters); the document did not
+        // change, so just repaint the overlay.
+        markNeedsPaint();
+        return;
+      }
+      // The composition also changed the document (a commit, or a selection
+      // replacement at composition start). Clear the lightweight repaint flags
+      // so neither the selectionOnly nor the bufferNeedsRepaint branch below
+      // swallows this change, and fall through to the content path, which
+      // refreshes caches, layout and highlighting for the edited line.
+      controller.selectionOnly = false;
+      controller.bufferNeedsRepaint = false;
+    }
+
     if (controller.selectionOnly) {
       controller.selectionOnly = false;
       if (!_isFoldToggleInProgress) {
@@ -6157,7 +6250,15 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
         !isRTL) {
       para = _paragraphCache[lineIndex]!;
     } else {
-      para = _buildParagraph(lineText, width: paragraphWidth);
+      // Measure against the highlighted paragraph so caret geometry matches the
+      // painted text and the IME composition overlay, which both lay out with
+      // per-token styles (e.g. bold keywords) whose glyph advances differ from
+      // the uniform plain style.
+      para = _buildHighlightedParagraph(
+        lineIndex,
+        lineText,
+        width: paragraphWidth,
+      );
     }
 
     final clampedCol = columnIndex.clamp(0, lineText.length);
@@ -6175,7 +6276,7 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
         final boxes = para.getBoxesForRange(0, 1);
         if (boxes.isNotEmpty) {
           caretX = boxes.first.right + paragraphOffset;
-          caretYInLine = boxes.first.top;
+          caretYInLine = _rowTopForBox(boxes.first);
         } else {
           caretX = contentWidth;
         }
@@ -6186,7 +6287,7 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
         );
         if (boxes.isNotEmpty) {
           caretX = boxes.first.left + paragraphOffset;
-          caretYInLine = boxes.first.top;
+          caretYInLine = _rowTopForBox(boxes.first);
         } else {
           caretX = paragraphOffset;
         }
@@ -6194,7 +6295,7 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
         final boxes = para.getBoxesForRange(clampedCol - 1, clampedCol);
         if (boxes.isNotEmpty) {
           caretX = boxes.first.left + paragraphOffset;
-          caretYInLine = boxes.first.top;
+          caretYInLine = _rowTopForBox(boxes.first);
         } else {
           caretX = contentWidth;
         }
@@ -6206,7 +6307,7 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
         final boxes = para.getBoxesForRange(clampedCol - 1, clampedCol);
         if (boxes.isNotEmpty) {
           caretX = boxes.first.right;
-          caretYInLine = boxes.first.top;
+          caretYInLine = _rowTopForBox(boxes.first);
         }
       }
     }
@@ -6260,7 +6361,15 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
         !isRTL) {
       para = _paragraphCache[lineIndex]!;
     } else {
-      para = _buildParagraph(lineText, width: paragraphWidth);
+      // Measure against the highlighted paragraph so caret geometry matches the
+      // painted text and the IME composition overlay, which both lay out with
+      // per-token styles (e.g. bold keywords) whose glyph advances differ from
+      // the uniform plain style.
+      para = _buildHighlightedParagraph(
+        lineIndex,
+        lineText,
+        width: paragraphWidth,
+      );
     }
 
     final clampedCol = columnIndex.clamp(0, lineText.length);
@@ -6277,7 +6386,7 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
         final boxes = para.getBoxesForRange(0, 1);
         if (boxes.isNotEmpty) {
           caretX = boxes.first.right + paragraphOffset;
-          caretYInLine = boxes.first.top;
+          caretYInLine = _rowTopForBox(boxes.first);
         } else {
           caretX = contentWidth;
         }
@@ -6288,7 +6397,7 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
         );
         if (boxes.isNotEmpty) {
           caretX = boxes.first.left + paragraphOffset;
-          caretYInLine = boxes.first.top;
+          caretYInLine = _rowTopForBox(boxes.first);
         } else {
           caretX = paragraphOffset;
         }
@@ -6296,7 +6405,7 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
         final boxes = para.getBoxesForRange(clampedCol - 1, clampedCol);
         if (boxes.isNotEmpty) {
           caretX = boxes.first.left + paragraphOffset;
-          caretYInLine = boxes.first.top;
+          caretYInLine = _rowTopForBox(boxes.first);
         } else {
           caretX = contentWidth;
         }
@@ -6308,7 +6417,7 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
         final boxes = para.getBoxesForRange(clampedCol - 1, clampedCol);
         if (boxes.isNotEmpty) {
           caretX = boxes.first.right;
-          caretYInLine = boxes.first.top;
+          caretYInLine = _rowTopForBox(boxes.first);
         }
       }
     }
@@ -6447,6 +6556,225 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
   }
 
   Offset getCaretOffset() => _getCaretInfo().offset;
+
+  /// Reports the editable region's size/transform and the caret rectangle to
+  /// the platform input method, so the OS places the IME composition/candidate
+  /// window next to the caret instead of at the window's top-left corner. The
+  /// caret rect is derived from the same [_getCaretInfo] used to paint the
+  /// cursor, so the reported geometry matches what is drawn. Redundant pushes
+  /// from cheap repaints (e.g. the cursor blink) are skipped via a cache.
+  void _updateImeGeometry() {
+    final conn = controller.connection;
+    if (conn == null || !conn.attached) return;
+    if (!vscrollController.hasClients || !hscrollController.hasClients) return;
+
+    final caretInfo = _getCaretInfo();
+    final hScroll = _effectiveHScroll;
+    final vScroll = vscrollController.offset;
+    final composing = controller.imeComposition != null;
+
+    double contentX(double dxInLine) => isRTL
+        ? size.width - _gutterWidth - (innerPadding?.right ?? 0) - dxInLine
+        : dxInLine + _gutterWidth + (innerPadding?.left ?? 0);
+
+    final caretY = caretInfo.offset.dy + (innerPadding?.top ?? 0);
+
+    // The caret rect tracks the composing caret while composing, otherwise the
+    // document caret.
+    final caretInLine =
+        caretInfo.offset.dx + (composing ? _imeComposingCaretDx : 0.0);
+    final caretRect = Rect.fromLTWH(
+      contentX(caretInLine) - hScroll,
+      caretY - vScroll,
+      2.0,
+      caretInfo.height,
+    );
+
+    // The composing rect spans the whole composing string from the anchor so
+    // the OS candidate window docks under the composition itself.
+    final composingRect = composing
+        ? Rect.fromLTWH(
+            contentX(caretInfo.offset.dx) - hScroll,
+            caretY - vScroll,
+            _imeComposingWidth > 0 ? _imeComposingWidth : 2.0,
+            caretInfo.height,
+          )
+        : caretRect;
+
+    final editableSize = size;
+
+    if (caretRect == _lastImeCaretRect &&
+        composingRect == _lastImeComposingRect &&
+        editableSize == _lastImeEditableSize) {
+      return;
+    }
+    _lastImeCaretRect = caretRect;
+    _lastImeComposingRect = composingRect;
+    _lastImeEditableSize = editableSize;
+
+    conn.setEditableSizeAndTransform(editableSize, getTransformTo(null));
+    conn.setCaretRect(caretRect);
+    conn.setComposingRect(composingRect);
+  }
+
+  /// Paints the in-progress IME composition (CJK pinyin/kana, etc.) as an
+  /// overlay at the composing anchor. The composing text is not part of the
+  /// document, so the committed line is painted normally and this overlay is
+  /// composited on top: the composing string (underlined) is drawn at the
+  /// anchor and the committed remainder of the line is shifted to its right,
+  /// mirroring how ghost text is rendered. Also records the composing caret
+  /// offset and width for [_updateImeGeometry].
+  void _drawImeComposition(Canvas canvas, Offset offset, bool hasActiveFolds) {
+    _imeComposingCaretDx = 0.0;
+    _imeComposingWidth = 0.0;
+
+    final comp = controller.imeComposition;
+    if (comp == null || comp.displayText.isEmpty) return;
+
+    final anchorLine = controller.getLineAtOffset(comp.anchor);
+    if (hasActiveFolds && _isLineFolded(anchorLine)) return;
+
+    final lineY = _getLineYOffset(anchorLine, hasActiveFolds);
+    // Match the committed line's Y: innerPadding.top + lineY + virtualOffset
+    // - scroll (virtualOffset covers any virtual-removed blocks above this line).
+    final virtualYOffset = _getTotalVirtualOffset(anchorLine);
+    final viewportHeight = vscrollController.position.viewportDimension;
+    final screenYBase =
+        offset.dy +
+        (innerPadding?.top ?? 0) +
+        lineY +
+        virtualYOffset -
+        vscrollController.offset;
+    if (screenYBase + _lineHeight < offset.dy ||
+        screenYBase > offset.dy + viewportHeight) {
+      return;
+    }
+
+    final lineStartOffset = controller.getLineStartOffset(anchorLine);
+    final anchorCol = comp.anchor - lineStartOffset;
+    final lineText =
+        _lineTextCache[anchorLine] ?? controller.getLineText(anchorLine);
+    final clampedCol = anchorCol.clamp(0, lineText.length);
+
+    final paragraphWidth = lineWrap ? _wrapWidth : null;
+    final linePara =
+        _paragraphCache[anchorLine] ??
+        _buildHighlightedParagraph(anchorLine, lineText, width: paragraphWidth);
+
+    double anchorX = 0;
+    double rowTop = 0;
+    if (lineText.isNotEmpty && clampedCol > 0) {
+      // Place the overlay on the same visual row as the anchor. The committed
+      // line is painted at the plain row top and applies its line-height leading
+      // internally; the overlay paragraph uses the same line-height, so it must
+      // sit at that row top to line up. [_rowTopForBox] derives the row from the
+      // glyph box center so a CJK glyph before the anchor does not push it a row
+      // too high (see that helper).
+      final boxes = linePara.getBoxesForRange(
+        0,
+        clampedCol,
+        boxHeightStyle: ui.BoxHeightStyle.max,
+      );
+      if (boxes.isNotEmpty) {
+        final lastBox = boxes.last;
+        anchorX = lastBox.right;
+        rowTop = _rowTopForBox(lastBox);
+      }
+    }
+
+    final scroll = lineWrap ? 0.0 : _effectiveHScroll;
+    final screenX =
+        offset.dx + _gutterWidth + (innerPadding?.left ?? 0) + anchorX - scroll;
+    final screenY = screenYBase + rowTop;
+
+    final baseColor =
+        textStyle?.color ?? editorTheme['root']?.color ?? Colors.white;
+    final bgColor = editorTheme['root']?.backgroundColor ?? Colors.black;
+    final fontSize = textStyle?.fontSize ?? 14.0;
+    final fontFamily = textStyle?.fontFamily;
+    final lineHeightMultiplier = textStyle?.height ?? 1.2;
+
+    final overlayParagraphStyle = ui.ParagraphStyle(
+      fontFamily: fontFamily,
+      fontSize: fontSize,
+      height: lineHeightMultiplier,
+      textDirection: textDirection,
+      textAlign: ui.TextAlign.start,
+    );
+
+    final composingStyle = ui.TextStyle(
+      color: baseColor,
+      fontSize: fontSize,
+      fontFamily: fontFamily,
+      decoration: TextDecoration.underline,
+      decorationColor: baseColor.withAlpha(150),
+    );
+    final composingBuilder = ui.ParagraphBuilder(overlayParagraphStyle)
+      ..pushStyle(composingStyle)
+      ..addText(comp.displayText);
+    final composingPara = composingBuilder.build();
+    composingPara.layout(const ui.ParagraphConstraints(width: double.infinity));
+    final composingWidth = composingPara.longestLine;
+
+    final remainderWidth = (linePara.longestLine - anchorX).clamp(
+      0.0,
+      double.infinity,
+    );
+
+    // Cover the area the composing text + shifted remainder will occupy, then
+    // paint the composing text and the shifted remainder over it.
+    canvas.drawRect(
+      Rect.fromLTWH(
+        screenX,
+        screenY,
+        composingWidth + remainderWidth + 2,
+        _lineHeight,
+      ),
+      Paint()..color = bgColor,
+    );
+
+    canvas.drawParagraph(composingPara, Offset(screenX, screenY));
+
+    if (clampedCol < lineText.length) {
+      final remainingText = lineText.substring(clampedCol);
+      final remainingStyle = ui.TextStyle(
+        color: baseColor,
+        fontSize: fontSize,
+        fontFamily: fontFamily,
+        fontWeight: textStyle?.fontWeight,
+      );
+      final remainingBuilder = ui.ParagraphBuilder(overlayParagraphStyle)
+        ..pushStyle(remainingStyle)
+        ..addText(remainingText);
+      final remainingPara = remainingBuilder.build();
+      remainingPara.layout(
+        const ui.ParagraphConstraints(width: double.infinity),
+      );
+      canvas.drawParagraph(
+        remainingPara,
+        Offset(screenX + composingWidth, screenY),
+      );
+    }
+
+    double caretDx = 0;
+    if (comp.displayCaret > 0) {
+      final caretBoxes = composingPara.getBoxesForRange(
+        0,
+        comp.displayCaret.clamp(0, comp.displayText.length),
+      );
+      if (caretBoxes.isNotEmpty) caretDx = caretBoxes.last.right;
+    }
+
+    _imeComposingCaretDx = caretDx;
+    _imeComposingWidth = composingWidth;
+
+    if (focusNode.hasFocus && caretBlinkController.value > 0.5) {
+      canvas.drawRect(
+        Rect.fromLTWH(screenX + caretDx, screenY, 1.5, _lineHeight),
+        _caretPainter,
+      );
+    }
+  }
 
   int getScrollbarLineNumberAtScrollOffset(double scrollOffset) {
     if (!vscrollController.hasClients || controller.lineCount == 0) {
@@ -6720,6 +7048,18 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
     _lineTextCache[lineIndex] = lineText;
 
     return height;
+  }
+
+  /// The top of the visual row a glyph [box] sits on, as a whole multiple of the
+  /// line height. Uses the box's vertical center, not its top: with
+  /// BoxHeightStyle.max a tall glyph (e.g. CJK) has a box top above the row
+  /// origin, so flooring the top would land a row too high; the center always
+  /// falls inside the glyph's own row, giving the right row for ASCII, CJK, and
+  /// wrapped continuation rows alike.
+  double _rowTopForBox(ui.TextBox box) {
+    final center = (box.top + box.bottom) / 2.0;
+    final rowIndex = (center / _lineHeight).floor();
+    return (rowIndex < 0 ? 0 : rowIndex) * _lineHeight;
   }
 
   double _getLineYOffset(int targetLine, bool hasActiveFolds) {
@@ -7153,7 +7493,14 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
       );
     }
 
-    if (focusNode.hasFocus && caretBlinkController.value > 0.5) {
+    // Composition overlay (CJK pinyin/kana, etc.). Painted on top of the line
+    // text; while it is active the document caret is hidden and the overlay
+    // draws its own (composing) caret.
+    _drawImeComposition(canvas, offset, hasActiveFolds);
+
+    if (focusNode.hasFocus &&
+        caretBlinkController.value > 0.5 &&
+        controller.imeComposition == null) {
       final caretInfo = _getCaretInfo();
 
       final scroll = lineWrap ? 0.0 : _effectiveHScroll;
@@ -7528,6 +7875,11 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
     }
 
     canvas.restore();
+
+    // Keep the platform IME informed of where the caret is on screen so the
+    // composition/candidate window follows the caret instead of docking at
+    // the window's top-left corner.
+    _updateImeGeometry();
   }
 
   void _drawGutter(
@@ -10673,6 +11025,13 @@ class _CodeFieldRenderer extends RenderBox implements MouseTrackerAnnotation {
           _selectWordAtOffset(textOffset);
         });
       } else {
+        // Acquire focus on pointer-down. Focus was previously requested only by
+        // a GestureDetector.onTap wrapper, which does not fire when the click is
+        // interpreted as a micro-drag or when the editor's own drag-selection
+        // recognizer wins the gesture arena. In those cases the selection was
+        // set (the line highlighted) but focus was never gained, so the IME was
+        // never shown and typing did nothing.
+        controller.focusNode?.requestFocus();
         _dtap.addPointer(event);
         _dtap.onDoubleTap = () {
           _selectWordAtOffset(textOffset);

--- a/lib/code_forge/controller.dart
+++ b/lib/code_forge/controller.dart
@@ -65,6 +65,51 @@ class CodeForgeController implements DeltaTextInputClient {
   TextRange _imeProjectionComposing = TextRange.empty;
   bool _suppressImeSync = false;
   CompoundOperationHandle? _imeCompositionUndoGroup;
+
+  // --- IME composition overlay state ---------------------------------------
+  // While a composition is active the composing text is NOT written to the
+  // document; it lives in [_imeComposition] and is painted as an overlay by the
+  // renderer (see [ImeComposition]). The fields below mirror the platform's
+  // editing value so each delta can be reduced to a single committed document
+  // edit on commit/cancel, leaving the document free of transient composing
+  // glyphs.
+  ImeComposition? _imeComposition;
+  // Authoritative mirror of the platform's TextEditingValue (text including any
+  // composing range, in projection-local coordinates).
+  String _imeMirrorText = '';
+  TextSelection _imeMirrorSelection = const TextSelection.collapsed(offset: 0);
+  TextRange _imeMirrorComposing = TextRange.empty;
+  // The committed projection-window content -- equals [_imeMirrorText] with the
+  // composing range excised, and is kept identical to the document's projected
+  // window. Diffed against the mirror's committed text to derive document edits.
+  String _imeWindowCommitted = '';
+  int _imeWindowStart = 0;
+  // Repaint signal consumed by the renderer when the composition overlay
+  // changes without a document edit (e.g. typing further pinyin letters).
+  bool imeCompositionChanged = false;
+  // The selection captured at the start of a platform input event, used to
+  // replace it when a composition begins over it. Some platforms collapse the
+  // selection in a separate event immediately before composing, so the live
+  // selection cannot be relied on to still be non-collapsed at composition
+  // start. Cleared on real caret moves and once consumed.
+  TextSelection? _pendingSelectionReplacement;
+  // When a composition replaces a selection that the platform keeps in its own
+  // value (insertion-semantics platforms), the selection is deleted from the
+  // document and the gap recorded here in mirror-local coordinates; the
+  // committed-text reconciliation then excises this region so the document does
+  // not re-grow it. Inactive when [_imeMirrorDeleteLen] is 0. [_imeMirrorDeletedText]
+  // is the exact text removed: the excision stays active only while the platform
+  // still holds that text at the recorded spot, and self-disables the moment the
+  // platform drops the selection on its own (so we never excise live text).
+  int _imeMirrorDeleteStart = -1;
+  int _imeMirrorDeleteLen = 0;
+  String _imeMirrorDeletedText = '';
+  // Tracks the user's actual intended keystrokes and the previous composing text.
+  // Used to distinguish between IME-generated separators (like a'a'a'a)
+  // and explicit user-typed punctuation.
+  String _rawTypedComposingText = '';
+  String _lastComposingText = '';
+
   bool _bufferDirty = false, bufferNeedsRepaint = false, selectionOnly = false;
   bool _imeProjectionDirty = true, _imeSelectionNeedsResync = false;
   bool deleteFoldRangeOnDeletingFirstLine = false;
@@ -159,7 +204,7 @@ class CodeForgeController implements DeltaTextInputClient {
               _codeActionTimer?.cancel();
               _codeActionTimer = Timer(
                 const Duration(milliseconds: 250),
-                () async {
+                    () async {
                   if (errors.isEmpty) {
                     if (!_isDisposed) codeActionsNotifier.value = null;
                     return;
@@ -321,8 +366,8 @@ class CodeForgeController implements DeltaTextInputClient {
       final currentSelection = selection;
       final isTypingLenMatch =
           currentText.length == _previousValue.length + 1 &&
-          currentSelection.extentOffset == _prevSelection.extentOffset + 1 &&
-          _isTyping;
+              currentSelection.extentOffset == _prevSelection.extentOffset + 1 &&
+              _isTyping;
 
       _lspTypingTimer?.cancel();
       _lspTypingTimer = Timer(_lspTypingDebounce, () async {
@@ -428,10 +473,10 @@ class CodeForgeController implements DeltaTextInputClient {
 
     if (_activeCompletionKey != null) {
       _queuedCompletionRequest = (
-        filePath: filePath,
-        prefix: prefix,
-        line: line,
-        character: character,
+      filePath: filePath,
+      prefix: prefix,
+      line: line,
+      character: character,
       );
       return;
     }
@@ -442,11 +487,11 @@ class CodeForgeController implements DeltaTextInputClient {
   }
 
   Future<void> _fetchCompletions(
-    int requestId,
-    String prefix,
-    int line,
-    int character,
-  ) async {
+      int requestId,
+      String prefix,
+      int line,
+      int character,
+      ) async {
     if (_isDisposed || !_lspReady || openedFile == null) return;
     await Future<void>.delayed(Duration.zero);
     final completions = await lspConfig!.getCompletions(
@@ -481,15 +526,15 @@ class CodeForgeController implements DeltaTextInputClient {
   }
 
   String _completionRequestKey(
-    ({String filePath, String prefix, int line, int character}) request,
-  ) {
+      ({String filePath, String prefix, int line, int character}) request,
+      ) {
     return '${request.filePath}|${request.line}|${request.character}|${request.prefix}';
   }
 
   /// The semantic tokens generated by the LSP server.
   /// Used for LSP based syntax highlighting.
   final ValueNotifier<(List<LspSemanticToken>?, int)> semanticTokens =
-      ValueNotifier((null, 0));
+  ValueNotifier((null, 0));
 
   int get documentVersion => _currentVersion;
 
@@ -590,6 +635,12 @@ class CodeForgeController implements DeltaTextInputClient {
 
   /// The text input connection to the platform.
   TextInputConnection? connection;
+
+  /// Set by the view layer. Invoked when the editor needs the platform input
+  /// connection hard-reset (close + re-attach) -- e.g. to make the IME drop an
+  /// in-progress composition and close its candidate window after the caret is
+  /// moved by a click during composition.
+  VoidCallback? requestImeReset;
 
   /// The range of text that has been modified and needs reprocessing.
   TextRange? dirtyRegion;
@@ -834,8 +885,8 @@ class CodeForgeController implements DeltaTextInputClient {
   }
 
   void _updateMultiCursorsFromList(
-    List<({int line, int character})> positions,
-  ) {
+      List<({int line, int character})> positions,
+      ) {
     _multiCursors.clear();
     final primaryLine = getLineAtOffset(selection.extentOffset);
     final primaryChar =
@@ -1045,8 +1096,8 @@ class CodeForgeController implements DeltaTextInputClient {
     if (suggestion is Map) {
       final dynamic insertText =
           suggestion['insertText'] ??
-          suggestion['value'] ??
-          suggestion['label'];
+              suggestion['value'] ??
+              suggestion['label'];
       return insertText is String ? insertText : '';
     }
     if (suggestion is String) {
@@ -1417,15 +1468,15 @@ class CodeForgeController implements DeltaTextInputClient {
                   oldRanges?[startLine] ?? foldings[startLine];
               if (existing == null) {
                 for (
-                  int offset = 1;
-                  offset <= 3 && existing == null;
-                  offset++
+                int offset = 1;
+                offset <= 3 && existing == null;
+                offset++
                 ) {
                   existing =
                       oldRanges?[startLine - offset] ??
-                      oldRanges?[startLine + offset] ??
-                      foldings[startLine - offset] ??
-                      foldings[startLine + offset];
+                          oldRanges?[startLine + offset] ??
+                          foldings[startLine - offset] ??
+                          foldings[startLine + offset];
                   if (existing != null) {
                     final oldSpan = existing.endIndex - existing.startIndex;
                     final newSpan = endLine - startLine;
@@ -1743,7 +1794,7 @@ class CodeForgeController implements DeltaTextInputClient {
         currentlySelectedSuggestion != null) {
       currentlySelectedSuggestion =
           (currentlySelectedSuggestion! - 1) %
-          suggestionsNotifier.value!.length;
+              suggestionsNotifier.value!.length;
       return;
     }
 
@@ -1805,7 +1856,7 @@ class CodeForgeController implements DeltaTextInputClient {
         currentlySelectedSuggestion != null) {
       currentlySelectedSuggestion =
           (currentlySelectedSuggestion! + 1) %
-          suggestionsNotifier.value!.length;
+              suggestionsNotifier.value!.length;
       return;
     }
 
@@ -2050,7 +2101,7 @@ class CodeForgeController implements DeltaTextInputClient {
     if (foldings.isEmpty) return text;
     final visLines = getLinesRange(0, lineCount);
     for (final fold
-        in foldings.values.where((f) => f != null).toList().reversed) {
+    in foldings.values.where((f) => f != null).toList().reversed) {
       if (!fold!.isFolded) continue;
       final start = fold.startIndex + 1;
       final end = fold.endIndex + 1;
@@ -2168,14 +2219,39 @@ class CodeForgeController implements DeltaTextInputClient {
   set selection(TextSelection newSelection) {
     if (_selection == newSelection) return;
 
+    if (isComposingActive) {
+      // An external caret move (e.g. a click) during composition force-commits
+      // the composition into the document at its anchor as a single edit, moves
+      // the caret to the requested location, and hard-resets the platform input
+      // connection so the OS closes its candidate window and abandons the
+      // session. (Pushing an empty composing range via setEditingState does not
+      // close the candidate window on desktop; a connection reset is the only
+      // reliable cross-platform mechanism.)
+      _selection = _commitCompositionAndRemapSelection(newSelection);
+      selectionOnly = true;
+      _isTyping = false;
+      _imeProjectionDirty = true;
+      requestImeReset?.call();
+      notifyListeners();
+      return;
+    }
+
     _flushBuffer();
 
+    // A real caret move abandons any selection pending IME replacement.
+    _pendingSelectionReplacement = null;
     _selection = newSelection;
     selectionOnly = true;
     _isTyping = false;
     _imeProjectionDirty = true;
 
-    _scheduleSyncToConnection();
+    // Push the new projection to the platform synchronously instead of on a
+    // 50ms debounce. The debounce left a window where the platform still held
+    // the old projection (or the full document) while the user started typing,
+    // so the next keystroke was diffed against a stale base and landed at the
+    // wrong offset. _syncToConnection is internally guarded against active
+    // compositions and suppressed regions, so this stays safe.
+    _syncToConnection();
 
     notifyListeners();
   }
@@ -2187,6 +2263,11 @@ class CodeForgeController implements DeltaTextInputClient {
   void setSelectionSilently(TextSelection newSelection) {
     if (_selection == newSelection) return;
 
+    if (isComposingActive) {
+      newSelection = _commitCompositionAndRemapSelection(newSelection);
+      requestImeReset?.call();
+    }
+    _pendingSelectionReplacement = null;
     _flushBuffer();
 
     final textLength = length;
@@ -2202,13 +2283,18 @@ class CodeForgeController implements DeltaTextInputClient {
     _isTyping = false;
     _imeProjectionDirty = true;
 
-    _scheduleSyncToConnection();
+    _syncToConnection();
     notifyListeners();
   }
 
   void setSelectionImmediately(TextSelection newSelection) {
     if (_selection == newSelection) return;
 
+    if (isComposingActive) {
+      newSelection = _commitCompositionAndRemapSelection(newSelection);
+      requestImeReset?.call();
+    }
+    _pendingSelectionReplacement = null;
     _flushBuffer();
 
     final textLength = length;
@@ -2222,8 +2308,9 @@ class CodeForgeController implements DeltaTextInputClient {
     _selection = newSelection;
     selectionOnly = true;
     _isTyping = false;
+    _imeProjectionDirty = true;
 
-    _scheduleSyncToConnection();
+    _syncToConnection();
 
     notifyListeners();
   }
@@ -2347,8 +2434,44 @@ class CodeForgeController implements DeltaTextInputClient {
 
   @protected
   @override
+  /// Text routed through the platform IME connection is delivered even when
+  /// the editor's FocusNode does not hold primary focus, but hardware-key
+  /// shortcuts (Ctrl+Z/Y, arrows, Home/End, ...) are only delivered to the
+  /// editor's key handler when it does. When the user types into a freshly
+  /// opened editor without clicking it first, grab focus so those shortcuts
+  /// work. Never re-focus mid-composition: gaining focus re-seeds the platform
+  /// editing state, which would reset the in-progress IME composition.
+  void _maybeAcquireFocusForInput() {
+    final node = focusNode;
+    if (node != null && !node.hasFocus && !isComposingActive) {
+      node.requestFocus();
+    }
+  }
+
   void updateEditingValueWithDeltas(List<TextEditingDelta> textEditingDeltas) {
     if (readOnly) return;
+
+    // Capture the selection before this event can mutate it, so a composition
+    // beginning over it can replace it even when the platform first sends a
+    // separate de-select event.
+    if (_imeComposition == null && !_selection.isCollapsed) {
+      _pendingSelectionReplacement = _selection;
+    }
+
+    // Route anything touching an IME composition through the overlay path,
+    // which keeps the composing text out of the document. Pure non-composing
+    // input keeps the original (buffer-optimized) fast path unchanged.
+    final involvesComposition =
+        _imeComposition != null ||
+        textEditingDeltas.any(
+          (d) => d.composing.isValid && !d.composing.isCollapsed,
+        );
+    if (involvesComposition) {
+      _processCompositionDeltas(textEditingDeltas);
+      return;
+    }
+
+    final wasComposingAtStart = isComposingActive;
 
     _ensureImeProjection();
     bool typingDetected = false;
@@ -2356,7 +2479,7 @@ class CodeForgeController implements DeltaTextInputClient {
     _suppressImeSync = true;
     _beginImeCompositionUndoGroup(
       textEditingDeltas.any(
-        (d) => d.composing.isValid && !d.composing.isCollapsed,
+            (d) => d.composing.isValid && !d.composing.isCollapsed,
       ),
     );
     for (final delta in textEditingDeltas) {
@@ -2386,8 +2509,8 @@ class CodeForgeController implements DeltaTextInputClient {
             mappedInsertionOffset < _selection.extentOffset;
         bool useCurrentSelection =
             _imeSelectionNeedsResync ||
-            delta.insertionOffset != _imeProjectionSelection.extentOffset ||
-            staleMappedOffset;
+                delta.insertionOffset != _imeProjectionSelection.extentOffset ||
+                staleMappedOffset;
         if (isBufferActive) useCurrentSelection = true;
         _imeSelectionNeedsResync = false;
 
@@ -2417,11 +2540,11 @@ class CodeForgeController implements DeltaTextInputClient {
             : mappedInsertionOffset;
         final insertionSelection = useCurrentSelection
             ? TextSelection.collapsed(
-                offset: insertionOffset + delta.textInserted.length,
-              )
+          offset: insertionOffset + delta.textInserted.length,
+        )
             : TextSelection.collapsed(
-                offset: insertionOffset + delta.textInserted.length,
-              );
+          offset: insertionOffset + delta.textInserted.length,
+        );
 
         _handleInsertion(
           insertionOffset,
@@ -2465,10 +2588,41 @@ class CodeForgeController implements DeltaTextInputClient {
 
     _imeProjectionDirty = true;
 
+    _maybeAcquireFocusForInput();
+
+    // Re-sync the platform whenever this edit left its editing value out of step
+    // with the projection window. The platform applies plain typing itself, so
+    // it stays in sync for ordinary edits; but an edit that diverges from the raw
+    // delta (auto-indent, bracket auto-close, closer-skip) or shifts line
+    // structure (sliding the window onto a different document slice) leaves it
+    // stale. A composition started against a stale value commits its text at the
+    // wrong offset (duplicating surrounding lines). Push only when it actually
+    // differs, so plain typing costs nothing.
+    _ensureImeProjection();
+    if (_platformValueDivergesFromProjection(textEditingDeltas)) {
+      _syncToConnection();
+    }
+
+    if (wasComposingAtStart && !isComposingActive) {
+      // The IME composition just ended. Flush the typing buffer so the rope is
+      // authoritative, then invalidate only the caret's line so the just-removed
+      // composing glyph is repainted from the rope -- it is gone from the
+      // document but the cached paragraph would otherwise still paint it. Scoped
+      // to the single affected line to avoid repainting the whole document.
+      _flushBuffer();
+      dirtyLine = _rope.getLineAtOffset(_selection.extentOffset);
+    }
+
     notifyListeners();
   }
 
   bool get isBufferActive => _bufferLineIndex != null && _bufferDirty;
+
+  /// Whether an IME composition (e.g. CJK pinyin/kana) is currently in
+  /// progress. While true, the platform input method owns the keyboard, so
+  /// hardware-key handlers must defer to it and external selection changes
+  /// must finalize the composition first.
+  bool get isComposingActive => _imeComposition != null;
   int? get bufferLineIndex => _bufferLineIndex;
   int get bufferLineRopeStart => _bufferLineRopeStart;
   String? get bufferLineText => _bufferLineText;
@@ -2481,9 +2635,9 @@ class CodeForgeController implements DeltaTextInputClient {
 
   /// Insert text at the current cursor position (or replace selection).
   void insertAtCurrentCursor(
-    String textToInsert, {
-    bool replaceTypedChar = false,
-  }) {
+      String textToInsert, {
+        bool replaceTypedChar = false,
+      }) {
     if (readOnly) return;
 
     _flushBuffer();
@@ -2492,8 +2646,8 @@ class CodeForgeController implements DeltaTextInputClient {
     final safePosition = cursorPosition.clamp(0, _rope.length);
     final currentLine = _rope.getLineAtOffset(safePosition);
     final isFolded = foldings.values.any(
-      (fold) =>
-          fold != null &&
+          (fold) =>
+      fold != null &&
           fold.isFolded &&
           currentLine > fold.startIndex &&
           currentLine <= fold.endIndex,
@@ -2535,7 +2689,9 @@ class CodeForgeController implements DeltaTextInputClient {
 
   void _syncToConnection() {
     if (_suppressImeSync) return;
-    if (_imeComposingGlobal.isValid && !_imeComposingGlobal.isCollapsed) {
+    // Never push editing state while the platform IME is driving a composition;
+    // the composing text is overlay-only and the mirror is authoritative.
+    if (_imeComposition != null) {
       return;
     }
     if (connection != null && connection!.attached) {
@@ -2554,6 +2710,31 @@ class CodeForgeController implements DeltaTextInputClient {
   void _invalidateImeSnapshotAndScheduleSync() {
     _imeProjectionDirty = true;
     _syncToConnection();
+  }
+
+  /// Whether the platform's editing value, after applying [deltas], differs from
+  /// the current projection ([_imeProjectionText], which the caller refreshes).
+  ///
+  /// The platform's post-batch value is reconstructed by replaying the deltas
+  /// over the pre-edit value each delta reports in `oldText`, using the
+  /// engine-equivalent [TextEditingDelta.apply]. A batch of only non-text updates
+  /// (selection/composing) never diverges. Matches for plain typing the platform
+  /// applied itself; differs when the edit diverged from the raw delta or slid
+  /// the projection window onto a different document slice.
+  bool _platformValueDivergesFromProjection(List<TextEditingDelta> deltas) {
+    if (connection == null || !connection!.attached) return false;
+    String? platformText;
+    for (final delta in deltas) {
+      if (delta is TextEditingDeltaNonTextUpdate) continue;
+      platformText = delta.oldText;
+      break;
+    }
+    if (platformText == null) return false;
+    var value = TextEditingValue(text: platformText);
+    for (final delta in deltas) {
+      value = delta.apply(value);
+    }
+    return value.text != _imeProjectionText;
   }
 
   Map<String, dynamic> _lspPositionForOffset(int offset) {
@@ -2643,12 +2824,21 @@ class CodeForgeController implements DeltaTextInputClient {
     final selectionStart = selection.start.clamp(0, documentLength);
     final selectionEnd = selection.end.clamp(selectionStart, documentLength);
     final caretOffset = selection.extentOffset.clamp(0, documentLength);
-    final selectionLine = getLineAtOffset(caretOffset);
-    final lineStart = (selectionLine - _imeProjectionLineRadius).clamp(
+    // Span the window across the ENTIRE selection (not just the caret line),
+    // each end padded by the radius. A multi-line selection whose far end lies
+    // beyond the caret line would otherwise fall outside the window and get its
+    // offsets clamped when projected, so the platform would replace the wrong
+    // range. For a collapsed selection this reduces to +/-radius about the caret.
+    final firstSelLine = getLineAtOffset(selectionStart);
+    final lastSelLine = getLineAtOffset(selectionEnd);
+    final caretLine = getLineAtOffset(caretOffset);
+    final anchorLow = firstSelLine < caretLine ? firstSelLine : caretLine;
+    final anchorHigh = lastSelLine > caretLine ? lastSelLine : caretLine;
+    final lineStart = (anchorLow - _imeProjectionLineRadius).clamp(
       0,
       lineCount - 1,
     );
-    final lineEnd = (selectionLine + _imeProjectionLineRadius).clamp(
+    final lineEnd = (anchorHigh + _imeProjectionLineRadius).clamp(
       0,
       lineCount - 1,
     );
@@ -2670,10 +2860,10 @@ class CodeForgeController implements DeltaTextInputClient {
       }
       final selectionTail = selectionEnd + halfWindow;
       final projectionEndOffset =
-          (projectionStartOffset + _imeProjectionMaxChars).clamp(
-            0,
-            documentLength,
-          );
+      (projectionStartOffset + _imeProjectionMaxChars).clamp(
+        0,
+        documentLength,
+      );
       if (selectionTail > projectionEndOffset) {
         projectionStartOffset = (selectionTail - _imeProjectionMaxChars).clamp(
           0,
@@ -2784,11 +2974,387 @@ class CodeForgeController implements DeltaTextInputClient {
   /// active, merging everything recorded since it was opened into a single
   /// undo entry. Safe to call when no group is open.
   void _endImeCompositionUndoGroupIfIdle() {
-    if (_imeCompositionUndoGroup != null &&
-        (!_imeComposingGlobal.isValid || _imeComposingGlobal.isCollapsed)) {
+    if (_imeCompositionUndoGroup != null && _imeComposition == null) {
       _imeCompositionUndoGroup!.end();
       _imeCompositionUndoGroup = null;
     }
+  }
+
+  // ===========================================================================
+  // IME composition overlay
+  // ===========================================================================
+  // Composition (CJK pinyin/kana, dead keys, etc.) is handled WITHOUT mutating
+  // the document while it is in progress. The platform's editing value is
+  // mirrored in [_imeMirrorText]/[_imeMirrorSelection]/[_imeMirrorComposing];
+  // its committed portion (the mirror with the composing range excised) is kept
+  // identical to the document's projected window. On every delta we apply the
+  // delta to the mirror with Flutter's own [TextEditingDelta.apply] (engine-
+  // equivalent), then reduce the change to at most one document edit -- the
+  // difference between the new committed text and the window. During a steady
+  // composition that difference is empty, so the document never holds transient
+  // composing glyphs; the committed result lands as a single edit on commit.
+
+  /// The active IME composition overlay, or null when no composition is in
+  /// progress. Read by the renderer to paint the composing string.
+  ImeComposition? get imeComposition => _imeComposition;
+
+  void _processCompositionDeltas(List<TextEditingDelta> deltas) {
+    _suppressImeSync = true;
+    final startingComposition = _imeComposition == null;
+    final selectionToReplace = startingComposition
+        ? _selectionToReplaceForComposition()
+        : null;
+    _seedImeMirrorIfIdle();
+    final replacement = _captureSelectionReplacement(selectionToReplace);
+    _beginImeCompositionUndoGroup(
+      deltas.any((d) => d.composing.isValid && !d.composing.isCollapsed),
+    );
+
+    var value = TextEditingValue(
+      text: _imeMirrorText,
+      selection: _imeMirrorSelection,
+      composing: _imeMirrorComposing,
+    );
+    for (final delta in deltas) {
+      value = delta.apply(value);
+      _reconcileCommittedToDocument(value);
+    }
+
+    _applyLingeringSelectionDeletion(replacement);
+    _finishImeMirrorUpdate(value);
+    final composingEnded = _imeComposition == null;
+    _suppressImeSync = false;
+    // Composition just finalized/cancelled: push the fresh committed projection
+    // so the platform's editing value and the document are exactly consistent.
+    if (composingEnded) _syncToConnection();
+    notifyListeners();
+  }
+
+  void _processCompositionValue(TextEditingValue value) {
+    _suppressImeSync = true;
+    final startingComposition = _imeComposition == null;
+    final selectionToReplace = startingComposition
+        ? _selectionToReplaceForComposition()
+        : null;
+    _seedImeMirrorIfIdle();
+    final replacement = _captureSelectionReplacement(selectionToReplace);
+    _beginImeCompositionUndoGroup(
+      value.composing.isValid && !value.composing.isCollapsed,
+    );
+    _reconcileCommittedToDocument(value);
+    _applyLingeringSelectionDeletion(replacement);
+    _finishImeMirrorUpdate(value);
+    final composingEnded = _imeComposition == null;
+    _suppressImeSync = false;
+    if (composingEnded) _syncToConnection();
+    notifyListeners();
+  }
+
+  /// Seeds the platform mirror from the current projection when no composition
+  /// is active yet. The projection is what was last sent to the platform, so
+  /// the first composing delta applies consistently against it.
+  void _seedImeMirrorIfIdle() {
+    if (_imeComposition != null) return;
+    // Make the document authoritative before freezing the window for the
+    // composition, so the committed window and document stay in lockstep.
+    _flushBuffer();
+    _ensureImeProjection();
+    _imeMirrorText = _imeProjectionText;
+    _imeMirrorSelection = _imeProjectionSelection;
+    _imeMirrorComposing = TextRange.empty;
+    _imeWindowStart = _imeProjectionStartOffset;
+    _imeWindowCommitted = _imeProjectionText;
+    _imeMirrorDeleteStart = -1;
+    _imeMirrorDeleteLen = 0;
+    _imeMirrorDeletedText = '';
+    _rawTypedComposingText = '';
+    _lastComposingText = '';
+  }
+
+  /// Applies the post-delta platform [value] to the mirror, then either updates
+  /// the visible overlay (still composing) or tears it down (commit/cancel).
+  void _finishImeMirrorUpdate(TextEditingValue value) {
+    _imeMirrorText = value.text;
+    _imeMirrorSelection = value.selection;
+    _imeMirrorComposing = value.composing;
+
+    final composingActive =
+        value.composing.isValid && !value.composing.isCollapsed;
+
+    if (composingActive) {
+      final newComposingText = value.text.substring(value.composing.start, value.composing.end);
+
+      // Incremental Intent Tracking:
+      // We distinguish between "content characters" (letters/numbers) and
+      // "separators" (like pinyin ' marks) by comparing the stripped length.
+      final strippedOld = _lastComposingText.replaceAll("'", "").replaceAll('\u2019', "");
+      final strippedNew = newComposingText.replaceAll("'", "").replaceAll('\u2019', "");
+
+      if (strippedNew.length > strippedOld.length) {
+        // Case 1: User typed a new content character.
+        _rawTypedComposingText += strippedNew.substring(strippedOld.length);
+      } else if (strippedNew.length < strippedOld.length) {
+        // Case 2: User deleted a content character via backspace.
+        final diff = strippedOld.length - strippedNew.length;
+        if (_rawTypedComposingText.length >= diff) {
+          _rawTypedComposingText = _rawTypedComposingText.substring(0, _rawTypedComposingText.length - diff);
+        } else {
+          _rawTypedComposingText = "";
+        }
+      } else if (newComposingText.length > _lastComposingText.length) {
+        // Case 3: Content length is same, but raw length increased.
+        // This means a separator (like ') was added.
+        _rawTypedComposingText += "'";
+      } else if (newComposingText.length < _lastComposingText.length) {
+        // Case 4: Content length is same, but raw length decreased.
+        // A separator was removed.
+        if (_rawTypedComposingText.endsWith("'") || _rawTypedComposingText.endsWith('\u2019')) {
+          _rawTypedComposingText = _rawTypedComposingText.substring(0, _rawTypedComposingText.length - 1);
+        }
+      }
+
+      _lastComposingText = newComposingText;
+      _updateCompositionOverlayFromMirror();
+    } else {
+      _imeComposition = null;
+      _pendingSelectionReplacement = null;
+      _imeMirrorDeleteStart = -1;
+      _imeMirrorDeleteLen = 0;
+      _imeMirrorDeletedText = '';
+      _rawTypedComposingText = '';
+      _lastComposingText = '';
+      _endImeCompositionUndoGroupIfIdle();
+      _imeProjectionDirty = true;
+    }
+
+    _selection = _documentSelectionFromMirror(value.selection);
+    imeCompositionChanged = true;
+    _maybeAcquireFocusForInput();
+  }
+
+  /// Reduces a post-delta platform [value] to at most one document edit: the
+  /// difference between its committed text (composing range excised) and the
+  /// current projected window. Leaves the document untouched while the change
+  /// is confined to the composing region (the common case while composing).
+  void _reconcileCommittedToDocument(TextEditingValue value) {
+    final composing = value.composing;
+    String committedNew;
+    if (composing.isValid && !composing.isCollapsed) {
+      committedNew =
+          value.text.substring(0, composing.start) +
+          value.text.substring(composing.end);
+    } else {
+      committedNew = value.text;
+    }
+
+    // When a composition replaced a selection that the platform still holds in
+    // its own value (insertion-semantics platforms keep the selected text and
+    // merely de-select it), excise that region from the platform's committed
+    // text so the document keeps it deleted. This stays active only while the
+    // platform actually still holds that exact text at the recorded spot; some
+    // platforms drop the selection themselves a keystroke or two later, after
+    // which excising would delete live text -- so we self-disable the moment the
+    // recorded text is no longer there.
+    if (_imeMirrorDeleteLen > 0 && _imeMirrorDeleteStart >= 0) {
+      final end = _imeMirrorDeleteStart + _imeMirrorDeleteLen;
+      if (end <= committedNew.length &&
+          committedNew.substring(_imeMirrorDeleteStart, end) ==
+              _imeMirrorDeletedText) {
+        committedNew =
+            committedNew.substring(0, _imeMirrorDeleteStart) +
+            committedNew.substring(end);
+      } else {
+        _imeMirrorDeleteStart = -1;
+        _imeMirrorDeleteLen = 0;
+        _imeMirrorDeletedText = '';
+      }
+    }
+
+    final committedOld = _imeWindowCommitted;
+    if (committedNew == committedOld) return;
+
+    final oldLen = committedOld.length;
+    final newLen = committedNew.length;
+    final maxPrefix = oldLen < newLen ? oldLen : newLen;
+    int prefix = 0;
+    while (prefix < maxPrefix &&
+        committedOld.codeUnitAt(prefix) == committedNew.codeUnitAt(prefix)) {
+      prefix++;
+    }
+    final oldTail = oldLen - prefix;
+    final newTail = newLen - prefix;
+    final maxSuffix = oldTail < newTail ? oldTail : newTail;
+    int suffix = 0;
+    while (suffix < maxSuffix &&
+        committedOld.codeUnitAt(oldLen - 1 - suffix) ==
+            committedNew.codeUnitAt(newLen - 1 - suffix)) {
+      suffix++;
+    }
+
+    final globalStart = _imeWindowStart + prefix;
+    final globalEnd = _imeWindowStart + oldLen - suffix;
+    final replacement = committedNew.substring(prefix, newLen - suffix);
+
+    // Single document edit (handles undo, LSP, dirty regions). Runs while
+    // _suppressImeSync is true, so it will not clobber the composing state or
+    // push a stale projection mid-composition.
+    replaceRange(globalStart, globalEnd, replacement);
+    _imeWindowCommitted = committedNew;
+  }
+
+  /// Builds the composition overlay state from the platform mirror's composing
+  /// range: the verbatim text/caret shown in the overlay, plus the user's typed
+  /// intent used only if a click force-commits the composition.
+  void _updateCompositionOverlayFromMirror() {
+    final comp = _imeMirrorComposing;
+    final raw = _imeMirrorText.substring(comp.start, comp.end);
+    var compStartLocal = comp.start;
+    if (_imeMirrorDeleteLen > 0 &&
+        compStartLocal >= _imeMirrorDeleteStart + _imeMirrorDeleteLen) {
+      compStartLocal -= _imeMirrorDeleteLen;
+    }
+    final anchorGlobal = (_imeWindowStart + compStartLocal).clamp(0, length);
+    final caretLocalRaw = (_imeMirrorSelection.extentOffset - comp.start).clamp(
+      0,
+      raw.length,
+    );
+    _imeComposition = ImeComposition(
+      anchor: anchorGlobal,
+      displayText: raw,
+      displayCaret: caretLocalRaw,
+      commitText: _rawTypedComposingText.isNotEmpty ? _rawTypedComposingText : raw,
+    );
+  }
+
+  /// Maps the platform-local selection to a document selection. While a
+  /// composition is active the document caret is collapsed at the anchor (the
+  /// composing text is overlay-only); otherwise the local offsets are shifted
+  /// by the window start.
+  TextSelection _documentSelectionFromMirror(TextSelection localSelection) {
+    final comp = _imeComposition;
+    if (comp != null) {
+      return TextSelection.collapsed(offset: comp.anchor);
+    }
+    final base = (_imeWindowStart + localSelection.baseOffset).clamp(0, length);
+    final extent = (_imeWindowStart + localSelection.extentOffset).clamp(
+      0,
+      length,
+    );
+    return TextSelection(baseOffset: base, extentOffset: extent);
+  }
+
+  /// Force-commits the active composition into the document at its anchor as a
+  /// single edit, then clears the overlay. Used when an external caret move
+  /// (e.g. a click) interrupts composition before the input method finalizes it;
+  /// it writes [ImeComposition.commitText] (the tracked user typed intent).
+  void _commitCompositionInPlace() {
+    final comp = _imeComposition;
+    if (comp == null) return;
+    _imeComposition = null;
+    if (comp.commitText.isNotEmpty) {
+      final wasSuppressed = _suppressImeSync;
+      _suppressImeSync = true;
+      replaceRange(comp.anchor, comp.anchor, comp.commitText);
+      _suppressImeSync = wasSuppressed;
+    }
+    _endImeCompositionUndoGroupIfIdle();
+    _imeMirrorText = '';
+    _imeMirrorSelection = const TextSelection.collapsed(offset: 0);
+    _imeMirrorComposing = TextRange.empty;
+    _imeWindowCommitted = '';
+    _pendingSelectionReplacement = null;
+    _imeMirrorDeleteStart = -1;
+    _imeMirrorDeleteLen = 0;
+    _imeMirrorDeletedText = '';
+    imeCompositionChanged = true;
+  }
+
+  /// Force-commits the active composition (see [_commitCompositionInPlace]) and
+  /// remaps an externally requested selection past the inserted text. The
+  /// overlay is not part of the document a hit-test resolved against, so once
+  /// the committed text is inserted at the anchor, every requested offset at or
+  /// after the anchor shifts right by its length. Returns [requested] unchanged
+  /// when there was nothing to commit.
+  TextSelection _commitCompositionAndRemapSelection(TextSelection requested) {
+    final comp = _imeComposition;
+    final anchor = comp?.anchor ?? -1;
+    final insertedLength = comp?.commitText.length ?? 0;
+    _commitCompositionInPlace();
+    if (insertedLength <= 0 || anchor < 0) return requested;
+    final base = requested.baseOffset > anchor
+        ? requested.baseOffset + insertedLength
+        : requested.baseOffset;
+    final extent = requested.extentOffset > anchor
+        ? requested.extentOffset + insertedLength
+        : requested.extentOffset;
+    if (base == requested.baseOffset && extent == requested.extentOffset) {
+      return requested;
+    }
+    return requested.copyWith(baseOffset: base, extentOffset: extent);
+  }
+
+  /// Resolves the selection that a starting composition should replace, or null
+  /// if there is nothing to replace. Uses the live selection when it is still
+  /// non-collapsed, otherwise falls back to [_pendingSelectionReplacement] (set
+  /// at the start of the platform event, before a separate de-select event may
+  /// have collapsed it) provided the caret collapsed to within that selection.
+  TextSelection? _selectionToReplaceForComposition() {
+    if (!_selection.isCollapsed) return _selection;
+    final pending = _pendingSelectionReplacement;
+    if (pending != null && !pending.isCollapsed) {
+      final caret = _selection.extentOffset;
+      if (caret >= pending.start && caret <= pending.end) return pending;
+    }
+    return null;
+  }
+
+  /// Captures the text of the selection a starting composition should replace,
+  /// in mirror-local coordinates. The projection window is expanded to contain
+  /// the whole selection (see [_ensureImeProjection]), so the selection lies
+  /// inside the committed window. An empty record means there is nothing to
+  /// replace.
+  ({int localStart, String text}) _captureSelectionReplacement(
+    TextSelection? sel,
+  ) {
+    if (sel == null || sel.isCollapsed) return (localStart: 0, text: '');
+    final localStart = sel.start - _imeWindowStart;
+    final localEnd = sel.end - _imeWindowStart;
+    if (localStart < 0 ||
+        localEnd > _imeWindowCommitted.length ||
+        localEnd <= localStart) {
+      return (localStart: 0, text: '');
+    }
+    return (
+      localStart: localStart,
+      text: _imeWindowCommitted.substring(localStart, localEnd),
+    );
+  }
+
+  /// After the first composition delta(s), if the platform left the selected
+  /// text in place (insertion semantics), delete it from the document as one
+  /// edit and record the gap so subsequent committed diffs stay aligned and the
+  /// composition commits at the selection start. A no-op when the platform
+  /// already replaced the selection (its text is no longer where it was) -- so
+  /// this stays correct for both replacement- and insertion-semantics platforms
+  /// and never double-deletes.
+  void _applyLingeringSelectionDeletion(
+    ({int localStart, String text}) capture,
+  ) {
+    if (capture.text.isEmpty) return;
+    final localStart = capture.localStart;
+    final localEnd = localStart + capture.text.length;
+    if (localEnd > _imeWindowCommitted.length) return;
+    if (_imeWindowCommitted.substring(localStart, localEnd) != capture.text) {
+      return;
+    }
+    final globalStart = _imeWindowStart + localStart;
+    replaceRange(globalStart, globalStart + capture.text.length, '');
+    _imeWindowCommitted =
+        _imeWindowCommitted.substring(0, localStart) +
+        _imeWindowCommitted.substring(localEnd);
+    _imeMirrorDeleteStart = localStart;
+    _imeMirrorDeleteLen = capture.text.length;
+    _imeMirrorDeletedText = capture.text;
   }
 
   /// Remove the selection or last char if the selection is empty (backspace key)
@@ -2845,7 +3411,7 @@ class CodeForgeController implements DeltaTextInputClient {
               final foldEndLineText = _rope.getLineText(foldEndLine);
               final foldEnd =
                   _rope.getLineStartOffset(foldEndLine) +
-                  foldEndLineText.length;
+                      foldEndLineText.length;
 
               deletedText = _rope.substring(foldStart, foldEnd);
               _rope.delete(foldStart, foldEnd);
@@ -2937,7 +3503,7 @@ class CodeForgeController implements DeltaTextInputClient {
         deletedText = _bufferLineText![localOffset];
         _bufferLineText =
             _bufferLineText!.substring(0, localOffset) +
-            _bufferLineText!.substring(localOffset + 1);
+                _bufferLineText!.substring(localOffset + 1);
         _selection = TextSelection.collapsed(offset: deleteOffset);
         _currentVersion++;
 
@@ -2962,7 +3528,7 @@ class CodeForgeController implements DeltaTextInputClient {
       deletedText = _bufferLineText![localOffset];
       _bufferLineText =
           _bufferLineText!.substring(0, localOffset) +
-          _bufferLineText!.substring(localOffset + 1);
+              _bufferLineText!.substring(localOffset + 1);
       _bufferDirty = true;
       _cachedBufferLines = null;
       _selection = TextSelection.collapsed(offset: deleteOffset);
@@ -3034,7 +3600,7 @@ class CodeForgeController implements DeltaTextInputClient {
               final foldEndLineText = _rope.getLineText(foldEndLine);
               final foldEnd =
                   _rope.getLineStartOffset(foldEndLine) +
-                  foldEndLineText.length;
+                      foldEndLineText.length;
 
               deletedText = _rope.substring(foldStart, foldEnd);
               _rope.delete(foldStart, foldEnd);
@@ -3123,7 +3689,7 @@ class CodeForgeController implements DeltaTextInputClient {
         deletedText = _bufferLineText![localOffset];
         _bufferLineText =
             _bufferLineText!.substring(0, localOffset) +
-            _bufferLineText!.substring(localOffset + 1);
+                _bufferLineText!.substring(localOffset + 1);
         _currentVersion++;
 
         bufferNeedsRepaint = true;
@@ -3147,7 +3713,7 @@ class CodeForgeController implements DeltaTextInputClient {
       deletedText = _bufferLineText![localOffset];
       _bufferLineText =
           _bufferLineText!.substring(0, localOffset) +
-          _bufferLineText!.substring(localOffset + 1);
+              _bufferLineText!.substring(localOffset + 1);
       _bufferDirty = true;
       _cachedBufferLines = null;
       _currentVersion++;
@@ -3198,6 +3764,14 @@ class CodeForgeController implements DeltaTextInputClient {
       focusNode?.unfocus();
     }
     _imeComposingGlobal = TextRange.empty;
+    _imeComposition = null;
+    _pendingSelectionReplacement = null;
+    _imeMirrorDeleteStart = -1;
+    _imeMirrorDeleteLen = 0;
+    _imeMirrorDeletedText = '';
+    _rawTypedComposingText = '';
+    _lastComposingText = '';
+    imeCompositionChanged = true;
     _imeCompositionUndoGroup?.end();
     _imeCompositionUndoGroup = null;
   }
@@ -3223,9 +3797,9 @@ class CodeForgeController implements DeltaTextInputClient {
   @protected
   @override
   void didChangeInputControl(
-    TextInputControl? oldControl,
-    TextInputControl? newControl,
-  ) {}
+      TextInputControl? oldControl,
+      TextInputControl? newControl,
+      ) {}
 
   @protected
   @override
@@ -3263,6 +3837,18 @@ class CodeForgeController implements DeltaTextInputClient {
   @override
   void updateEditingValue(TextEditingValue value) {
     if (readOnly) return;
+
+    if (_imeComposition == null && !_selection.isCollapsed) {
+      _pendingSelectionReplacement = _selection;
+    }
+
+    final involvesComposition =
+        _imeComposition != null ||
+        (value.composing.isValid && !value.composing.isCollapsed);
+    if (involvesComposition) {
+      _processCompositionValue(value);
+      return;
+    }
 
     _suppressImeSync = true;
     _ensureImeProjection();
@@ -3317,6 +3903,7 @@ class CodeForgeController implements DeltaTextInputClient {
     );
     _endImeCompositionUndoGroupIfIdle();
     _suppressImeSync = false;
+    _maybeAcquireFocusForInput();
     notifyListeners();
   }
 
@@ -3360,11 +3947,11 @@ class CodeForgeController implements DeltaTextInputClient {
   /// Replace a range of text with new text.
   /// Used for clipboard operations and text manipulation.
   void replaceRange(
-    int start,
-    int end,
-    String replacement, {
-    bool preserveOldCursor = false,
-  }) {
+      int start,
+      int end,
+      String replacement, {
+        bool preserveOldCursor = false,
+      }) {
     if (_undoController?.isUndoRedoInProgress ?? false) return;
 
     if (!_suppressImeSync) _imeComposingGlobal = TextRange.empty;
@@ -3447,10 +4034,10 @@ class CodeForgeController implements DeltaTextInputClient {
   /// match, sets `searchHighlightsChanged = true` and calls
   /// `notifyListeners()` to request a repaint/update.
   void findWord(
-    String word, {
-    bool matchCase = false,
-    bool matchWholeWord = false,
-  }) {
+      String word, {
+        bool matchCase = false,
+        bool matchWholeWord = false,
+      }) {
     searchHighlights.clear();
 
     if (word.isEmpty) {
@@ -3598,9 +4185,9 @@ class CodeForgeController implements DeltaTextInputClient {
       final unindentedBlock = lines
           .map(
             (line) => line.startsWith(tabSpace)
-                ? line.substring(tabSize)
-                : line.replaceFirst(RegExp(r'^ +'), ''),
-          )
+            ? line.substring(tabSize)
+            : line.replaceFirst(RegExp(r'^ +'), ''),
+      )
           .join('\n');
 
       int removedChars = 0;
@@ -3614,7 +4201,7 @@ class CodeForgeController implements DeltaTextInputClient {
 
       final newSelection = TextSelection(
         baseOffset:
-            selection.baseOffset -
+        selection.baseOffset -
             (lines.first.startsWith(tabSpace)
                 ? tabSize
                 : (RegExp(r'^ +').stringMatch(lines.first)?.length ?? 0)),
@@ -3889,10 +4476,10 @@ class CodeForgeController implements DeltaTextInputClient {
             if (start == null || end == null) continue;
             final startOffset =
                 getLineStartOffset(start['line'] as int) +
-                (start['character'] as int);
+                    (start['character'] as int);
             final endOffset =
                 getLineStartOffset(end['line'] as int) +
-                (end['character'] as int);
+                    (end['character'] as int);
             final newText = e['newText'] as String? ?? '';
             converted.add({
               'start': startOffset,
@@ -3904,7 +4491,7 @@ class CodeForgeController implements DeltaTextInputClient {
           }
         }
         converted.sort(
-          (a, b) => (b['start'] as int).compareTo(a['start'] as int),
+              (a, b) => (b['start'] as int).compareTo(a['start'] as int),
         );
         for (final ce in converted) {
           replaceRange(
@@ -3937,10 +4524,10 @@ class CodeForgeController implements DeltaTextInputClient {
                 if (start == null || end == null) continue;
                 final int startOffset =
                     getLineStartOffset(start['line'] as int) +
-                    (start['character'] as int);
+                        (start['character'] as int);
                 final int endOffset =
                     getLineStartOffset(end['line'] as int) +
-                    (end['character'] as int);
+                        (end['character'] as int);
                 final String newText = e['newText'] as String? ?? '';
                 converted.add({
                   'start': startOffset,
@@ -3952,7 +4539,7 @@ class CodeForgeController implements DeltaTextInputClient {
               }
             }
             converted.sort(
-              (a, b) => (b['start'] as int).compareTo(a['start'] as int),
+                  (a, b) => (b['start'] as int).compareTo(a['start'] as int),
             );
             for (final ce in converted) {
               replaceRange(
@@ -3981,10 +4568,10 @@ class CodeForgeController implements DeltaTextInputClient {
           if (start == null || end == null) return;
           final startOffset =
               getLineStartOffset(start['line'] as int) +
-              (start['character'] as int);
+                  (start['character'] as int);
           final endOffset =
               getLineStartOffset(end['line'] as int) +
-              (end['character'] as int);
+                  (end['character'] as int);
           final newText = item['newText'] as String? ?? '';
           converted.add({
             'start': startOffset,
@@ -3996,7 +4583,7 @@ class CodeForgeController implements DeltaTextInputClient {
         return;
       }
       converted.sort(
-        (a, b) => (b['start'] as int).compareTo(a['start'] as int),
+            (a, b) => (b['start'] as int).compareTo(a['start'] as int),
       );
       for (final ce in converted) {
         replaceRange(
@@ -4293,10 +4880,10 @@ class CodeForgeController implements DeltaTextInputClient {
         dirtyRegion = TextRange(start: offset, end: offset);
 
       case ReplaceOperation(
-        :final offset,
-        :final deletedText,
-        :final insertedText,
-        :final selectionAfter,
+          :final offset,
+          :final deletedText,
+          :final insertedText,
+          :final selectionAfter,
       ):
         if (deletedText.isNotEmpty) {
           _rope.delete(offset, offset + deletedText.length);
@@ -4332,11 +4919,11 @@ class CodeForgeController implements DeltaTextInputClient {
   }
 
   void _recordInsertion(
-    int offset,
-    String text,
-    TextSelection selBefore,
-    TextSelection selAfter,
-  ) {
+      int offset,
+      String text,
+      TextSelection selBefore,
+      TextSelection selAfter,
+      ) {
     if (_undoController?.isUndoRedoInProgress ?? false) return;
     _recordEdit(
       InsertOperation(
@@ -4352,11 +4939,11 @@ class CodeForgeController implements DeltaTextInputClient {
   }
 
   void _recordDeletion(
-    int offset,
-    String text,
-    TextSelection selBefore,
-    TextSelection selAfter,
-  ) {
+      int offset,
+      String text,
+      TextSelection selBefore,
+      TextSelection selAfter,
+      ) {
     if (_undoController?.isUndoRedoInProgress ?? false) return;
     _recordEdit(
       DeleteOperation(
@@ -4372,12 +4959,12 @@ class CodeForgeController implements DeltaTextInputClient {
   }
 
   void _recordReplacement(
-    int offset,
-    String deleted,
-    String inserted,
-    TextSelection selBefore,
-    TextSelection selAfter,
-  ) {
+      int offset,
+      String deleted,
+      String inserted,
+      TextSelection selBefore,
+      TextSelection selAfter,
+      ) {
     if (_undoController?.isUndoRedoInProgress ?? false) return;
     _recordEdit(
       ReplaceOperation(
@@ -4445,10 +5032,10 @@ class CodeForgeController implements DeltaTextInputClient {
   }
 
   void _handleInsertion(
-    int offset,
-    String insertedText,
-    TextSelection newSelection,
-  ) {
+      int offset,
+      String insertedText,
+      TextSelection newSelection,
+      ) {
     if (_undoController?.isUndoRedoInProgress ?? false) return;
 
     if (hasMultiCursors &&
@@ -4566,8 +5153,8 @@ class CodeForgeController implements DeltaTextInputClient {
           if (localOffset >= 0 && localOffset <= _bufferLineText!.length) {
             _bufferLineText =
                 _bufferLineText!.substring(0, localOffset) +
-                actualInsertedText +
-                _bufferLineText!.substring(localOffset);
+                    actualInsertedText +
+                    _bufferLineText!.substring(localOffset);
             _selection = actualSelection;
             _currentVersion++;
             dirtyLine = _bufferLineIndex;
@@ -4598,8 +5185,8 @@ class CodeForgeController implements DeltaTextInputClient {
       if (localOffset >= 0 && localOffset <= _bufferLineText!.length) {
         _bufferLineText =
             _bufferLineText!.substring(0, localOffset) +
-            actualInsertedText +
-            _bufferLineText!.substring(localOffset);
+                actualInsertedText +
+                _bufferLineText!.substring(localOffset);
         _bufferDirty = true;
         _cachedBufferLines = null;
         _selection = actualSelection;
@@ -4631,8 +5218,8 @@ class CodeForgeController implements DeltaTextInputClient {
         if (localOffset >= 0 && localOffset <= _bufferLineText!.length) {
           _bufferLineText =
               _bufferLineText!.substring(0, localOffset) +
-              actualInsertedText +
-              _bufferLineText!.substring(localOffset);
+                  actualInsertedText +
+                  _bufferLineText!.substring(localOffset);
           _selection = actualSelection;
           _currentVersion++;
 
@@ -4661,8 +5248,8 @@ class CodeForgeController implements DeltaTextInputClient {
     if (localOffset >= 0 && localOffset <= _bufferLineText!.length) {
       _bufferLineText =
           _bufferLineText!.substring(0, localOffset) +
-          actualInsertedText +
-          _bufferLineText!.substring(localOffset);
+              actualInsertedText +
+              _bufferLineText!.substring(localOffset);
       _bufferDirty = true;
       _cachedBufferLines = null;
       _selection = actualSelection;
@@ -4735,7 +5322,7 @@ class CodeForgeController implements DeltaTextInputClient {
 
           _bufferLineText =
               _bufferLineText!.substring(0, localStart) +
-              _bufferLineText!.substring(localEnd);
+                  _bufferLineText!.substring(localEnd);
           _selection = newSelection;
           _currentVersion++;
 
@@ -4799,7 +5386,7 @@ class CodeForgeController implements DeltaTextInputClient {
       deletedText = _bufferLineText!.substring(localStart, localEnd);
       _bufferLineText =
           _bufferLineText!.substring(0, localStart) +
-          _bufferLineText!.substring(localEnd);
+              _bufferLineText!.substring(localEnd);
       _bufferDirty = true;
       _cachedBufferLines = null;
       _selection = newSelection;
@@ -4817,10 +5404,10 @@ class CodeForgeController implements DeltaTextInputClient {
   }
 
   void _handleReplacement(
-    TextRange range,
-    String text,
-    TextSelection newSelection,
-  ) {
+      TextRange range,
+      String text,
+      TextSelection newSelection,
+      ) {
     if (_undoController?.isUndoRedoInProgress ?? false) return;
 
     final selectionBefore = _selection;

--- a/lib/code_forge/styling.dart
+++ b/lib/code_forge/styling.dart
@@ -833,6 +833,58 @@ class GhostText {
   });
 }
 
+/// An in-progress IME composition (e.g. CJK pinyin/kana), rendered as a
+/// transient overlay above the document rather than written into it.
+///
+/// While a composition is active the editor's document (rope) is left
+/// untouched; the composing text lives only in an instance of this class and
+/// is painted at [anchor]. The committed result is written to the document as
+/// a single edit only when the platform input method finalizes the
+/// composition. This keeps the document free of transient composing glyphs
+/// and lets the editor render the composing string itself. [displayText]
+/// preserves the platform composing string for display (for example `hao'jia`),
+/// while [commitText] stores the user's typed intent for interruption commits.
+@immutable
+class ImeComposition {
+  /// Global document offset where composition starts.
+  final int anchor;
+
+  /// The text displayed in the IME overlay (exactly as reported by the platform).
+  /// This includes any input method decorators like pinyin separators (a'a'a'a).
+  final String displayText;
+
+  /// Local caret position within [displayText].
+  final int displayCaret;
+
+  /// The intended text to be committed if the composition is interrupted.
+  /// This is determined by the Incremental Intent Tracking algorithm to
+  /// distinguish between user-typed characters and IME-auto-generated characters.
+  final String commitText;
+
+  ImeComposition({
+    required this.anchor,
+    required this.displayText,
+    required this.displayCaret,
+    required this.commitText,
+  });
+
+  /// Whether there is no composing text (an inactive composition).
+  bool get isEmpty => displayText.isEmpty;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImeComposition &&
+          other.anchor == anchor &&
+          other.displayText == displayText &&
+          other.displayCaret == displayCaret &&
+          other.commitText == commitText;
+
+  @override
+  int get hashCode =>
+      Object.hash(anchor, displayText, displayCaret, commitText);
+}
+
 /// Represents a block of removed lines to be displayed virtually in the editor.
 ///
 /// Virtual removed lines appear between real document lines, showing

--- a/lib/code_forge/undo_redo.dart
+++ b/lib/code_forge/undo_redo.dart
@@ -374,7 +374,7 @@ class CompoundOperationHandle {
   bool _isActive = true;
 
   CompoundOperationHandle._(this._controller)
-    : _startStackSize = _controller._undoStack.length;
+      : _startStackSize = _controller._undoStack.length;
 
   /// End the compound operation, combining all recorded edits into one.
   void end() {

--- a/rust/src/api/rope.rs
+++ b/rust/src/api/rope.rs
@@ -78,8 +78,14 @@ impl RopeBridge {
             rope_write.insert(safe_start, &replacement);
         }
 
+        // The selection is expressed in character offsets (the rope indexes by
+        // char), so advance by the replacement's character count, not its UTF-8
+        // byte length -- otherwise multi-byte text (e.g. CJK) over-advances the
+        // caret by (bytes - chars), which is what corrupts the cursor restored
+        // by redo after committing CJK input.
+        let replacement_chars = replacement.chars().count();
         let new_selection = if preserve_old_cursor {
-            let delta = replacement.len() as isize - (safe_end - safe_start) as isize;
+            let delta = replacement_chars as isize - (safe_end - safe_start) as isize;
 
             let map_offset = |offset: usize| -> usize {
                 if offset <= safe_start {
@@ -89,7 +95,7 @@ impl RopeBridge {
                     mapped.clamp(0, rope_write.len_chars() as isize) as usize
                 } else {
                     let relative = offset.saturating_sub(safe_start);
-                    let mapped = safe_start + relative.min(replacement.len());
+                    let mapped = safe_start + relative.min(replacement_chars);
                     mapped.min(rope_write.len_chars())
                 }
             };
@@ -102,8 +108,8 @@ impl RopeBridge {
             }
         } else {
             SelectionState {
-                base_offset: safe_start + replacement.len(),
-                extent_offset: safe_start + replacement.len(),
+                base_offset: safe_start + replacement_chars,
+                extent_offset: safe_start + replacement_chars,
             }
         };
 


### PR DESCRIPTION
# PR: Stabilize cross-platform IME composition and editor input

## Summary

This PR fixes the editor's IME and keyboard-input behavior across desktop and mobile paths by replacing the old "write composing text into the rope" approach with a composition overlay model.

While an IME composition is active, the document is no longer mutated by transient composing text. The controller mirrors the platform `TextEditingValue`, paints the composing string as an overlay, and reconciles only committed text back into the rope. This keeps the document, undo stack, LSP sync, paint cache, and platform IME state aligned.

The PR also fixes focus routing, candidate-window placement, selected-range replacement during composition, CJK word selection, and CJK redo/caret offsets in the Rust rope bridge.

## Problems fixed

### IME/text input activation and focus routing

The editor could receive text from an already-attached `TextInputConnection` even when the editor's `FocusNode` did not hold primary focus. Hardware-key shortcuts such as Ctrl+Z/Ctrl+Y, arrows, Home/End, and other key handlers only route through the editor when the focus node is primary.

This caused a freshly opened editor to accept typed text while shortcuts did not work until the user clicked the editor.

Fixes:

- Call `TextInputConnection.show()` whenever the editor gains focus, even if the connection is already attached.
- Seed the platform with `currentTextEditingValue` (the IME projection window), not the full document.
- Acquire editor focus when platform text input arrives without a prior click.
- Request focus on render-object pointer down, not only through the outer tap gesture, so micro-drags and editor-owned selection gestures still focus the editor.

### Composition text no longer mutates the document while composing

The previous path wrote pinyin/kana/etc. composing text directly into the rope and then tried to reconcile later IME updates against a projected text window. This made transient IME state visible to editor subsystems that should only see committed document content.

Fixes:

- Add an `ImeComposition` overlay state.
- Mirror platform text input in `_imeMirrorText`, `_imeMirrorSelection`, and `_imeMirrorComposing`.
- Keep `_imeWindowCommitted` equal to the document's projected window with the composing range removed.
- Apply each `TextEditingDelta` to the mirror using Flutter's `TextEditingDelta.apply()` semantics.
- Diff only the committed mirror text against the committed window and apply at most one `replaceRange` per committed change.
- Leave ordinary non-composition input on the existing buffer-optimized fast path.

Effect:

- During steady composition, the rope stays frozen.
- Backspacing within a composition does not leave phantom characters in the document or paint cache.
- Final candidate selection lands as a single document edit.
- Undo/LSP see committed edits rather than every transient pinyin/kana update.

### Selected text is replaced when composition starts

Starting an IME composition over a selected range should replace that range. Some platforms preserve the selection long enough for the app to see it; others collapse the selection in a separate event before the first composing update; others keep the selected text in the platform editing value while effectively inserting at the selection start.

Fixes:

- Capture a pending non-collapsed selection before platform input mutates it.
- Expand the IME projection window to include the entire selected range, not just the caret line.
- Delete lingering selected text when the platform keeps it in its value, while self-disabling the excision as soon as the platform drops that text.
- Commit the composition at the selection start.

Effect:

- Selecting code and then typing pinyin replaces the selected code, instead of inserting beside it or leaving the selection intact.

### Hardware keys are deferred to the IME during composition

During active composition, keys such as Backspace are owned by the input method. Handling them again through the editor's `onKeyEvent` path can double-edit the rope and desynchronize the platform composing state from the document.

Fix:

- `onKeyEvent` returns `KeyEventResult.ignored` while `controller.isComposingActive` is true.

Effect:

- Backspacing through strings such as `haojiahuo` no longer leaves a ghost character or deletes the previous real character on the next Backspace.

### Clicking elsewhere during composition is deterministic

Flutter does not expose a Dart-level API to force the platform IME to commit or cancel an active composition while keeping the same connection. On desktop, pushing an empty composing range is not sufficient to close the candidate window reliably.

Fix:

- When an external selection change occurs during composition, commit the overlay at its original anchor using the tracked typed intent.
- Remap the requested selection past the inserted text so hit-tested offsets remain correct after the commit.
- Request a platform input connection reset (`close` + re-attach) so the OS drops the active composition session and closes the candidate window.

Effect:

- Clicking elsewhere during composition commits the visible typed intent in place, moves the caret to the clicked location, and closes the candidate window.

Note: the close/re-attach is intentionally limited to this interruption path. Normal composition and normal typing do not pay this cost.

### Candidate window follows the caret/composition

The editor previously did not report caret/composing geometry to the platform. Without `setEditableSizeAndTransform`, `setCaretRect`, and `setComposingRect`, the OS can place the IME candidate window at the window corner or another fallback position.

Fixes:

- Report editable size and transform to the platform.
- Report caret rect and composing rect using the same caret geometry used for editor painting.
- During composition, track the overlay caret and composing width so the platform candidate window follows the composition caret/string rather than the frozen document caret.
- Cache the last reported geometry to skip redundant updates on cheap repaints such as cursor blinking.

### Composition overlay alignment

The composition overlay now uses the same visual row model as the painted text.

Fixes:

- Measure caret/overlay positions against highlighted paragraphs, not a plain paragraph with potentially different glyph advances.
- Derive row top from the text box center so tall glyph boxes such as CJK characters do not place the overlay one row too high.
- Paint the composing string as an underlined overlay and shift the committed remainder of the line to the right.
- Hide the normal document caret while the overlay draws its own composing caret.

Effect:

- Composing text such as `haojia`/`hao'jia` no longer appears vertically offset and no longer jumps when the composition is interrupted or committed.

### Pinyin separator behavior

The overlay displays the platform's raw composing text. For Windows Pinyin, that means a composition such as `hao'jia` is displayed as `hao'jia` while composing.

For interruption commits, the controller uses incremental typed-intent tracking:

- IME-generated pinyin separators are not written into the document when a composition is interrupted by clicking elsewhere.
- User-typed separators are preserved.

Example behavior:

- Type pinyin `haojia`; while composing, the IME/editor may display `hao'jia`.
- Click elsewhere before choosing a candidate; the document keeps `haojia`.
- If the user explicitly types `hao'jia`, the document keeps `hao'jia`.

### CJK word selection

The editor's word-character pattern now includes CJK ranges for Hiragana, Katakana, CJK Extension A, CJK Unified Ideographs, Hangul Syllables, and CJK Compatibility Ideographs.

Effect:

- Double-clicking CJK text selects the contiguous CJK run instead of treating each glyph as a boundary.
- CJK punctuation remains a boundary.

### Rust rope selection offsets after multi-byte replacements

`rust/src/api/rope.rs` previously advanced replacement selections using `replacement.len()`, which is UTF-8 byte length. The rope indexes by character offsets, so multi-byte replacement text such as CJK could over-advance the restored caret/selection, especially after redo.

Fix:

- Use `replacement.chars().count()` for replacement selection mapping.

## Files changed

- `lib/code_forge/code_area.dart`
  - IME connection attach/reset helper.
  - Focus/IME activation fixes.
  - Key-event composition guard.
  - IME geometry reporting.
  - Composition overlay painting/alignment.
  - Pointer-down focus acquisition.
  - CJK word-character pattern.

- `lib/code_forge/controller.dart`
  - Composition overlay state and platform mirror.
  - Delta/full-value composition paths.
  - Committed-text reconciliation.
  - Selection replacement handling.
  - Typed-intent tracking for interrupted commits.
  - Focus acquisition on input.
  - Selection sync and platform resync guards.

- `lib/code_forge/styling.dart`
  - `ImeComposition` model.

- `lib/code_forge/undo_redo.dart`
  - Formatting-only constructor alignment.

- `rust/src/api/rope.rs`
  - Character-count based selection mapping for replacements.

## Performance notes

The steady-state path remains lightweight:

- Non-composition input stays on the existing fast path.
- During composition, pure composing changes repaint only the overlay when the document content version is unchanged.
- The document rope, LSP sync, and syntax/highlight caches are not updated for transient composing text.
- IME geometry updates are cached and skipped when unchanged.
- The platform connection reset only happens when composition is interrupted by an external caret move.

## Testing
Tested and verified on Windows and macOS:
- Open the editor and type immediately without clicking; text input works and Ctrl+Z/Ctrl+Y/arrows/Home/End work after typing.
- Click into the editor after first open and type ASCII/CJK; text lands at the clicked caret position.
- Type pinyin such as `haojiahuo`, backspace through it, and confirm no phantom letters remain and no previous real character is deleted unexpectedly.
- Select a range of code, start a pinyin composition, choose/commit text, and confirm the selected range is replaced.
- While composing pinyin, click another editor position; the visible typed intent commits at the original anchor, the candidate window closes, and the caret moves to the clicked position.
- Type `haojia`; confirm the composition display may show IME raw text such as `hao'jia`, but an interrupted commit leaves `haojia` in the document.
- Explicitly type `hao'jia`; confirm the manually typed apostrophe is preserved.
- Confirm the IME candidate window follows the caret/composition rather than appearing in the top-left corner.
- Confirm the composing overlay sits on the same baseline/row as committed text, including after CJK text and wrapped lines.
- Double-click CJK text and confirm the contiguous CJK run is selected.
- Commit CJK text, undo/redo it, and confirm the caret/selection restore to character-correct offsets.
