### PR TITLE
support Ctrl+Shift+Z to Redo

### DIFF
--- a/lib/code_forge/code_area.dart
+++ b/lib/code_forge/code_area.dart
@@ -2385,7 +2385,15 @@ class _CodeForgeState extends State<CodeForge> with TickerProviderStateMixin {
                                                           return KeyEventResult
                                                               .handled;
                                                         }
-                                                        if (_undoRedoController
+                                                        // Ctrl+Shift+Z to redo
+                                                        if (isShiftPressed) {
+                                                          if (_undoRedoController
+                                                              .canRedo) {
+                                                            _undoRedoController
+                                                                .redo();
+                                                            _commonKeyFunctions();
+                                                          }
+                                                        } else if (_undoRedoController
                                                             .canUndo) {
                                                           _undoRedoController
                                                               .undo();


### PR DESCRIPTION
hi, thx your work! I added Ctrl+Shift+Z to Redo, because it’s used as often as Ctrl+Y.
