### PR TITLE
support read rustup toolchain from env

### DIFF
--- a/cargokit/build_tool/lib/src/builder.dart
+++ b/cargokit/build_tool/lib/src/builder.dart
@@ -1,6 +1,8 @@
 /// This is copied from Cargokit (which is the official way to use it currently)
 /// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
 
+import 'dart:io';
+
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -139,7 +141,10 @@ class RustBuilder {
   CargoBuildOptions? get _buildOptions =>
       environment.crateOptions.cargo[environment.configuration];
 
-  String get _toolchain => _buildOptions?.toolchain.name ?? 'stable';
+  String get _toolchain =>
+      Platform.environment['RUSTUP_TOOLCHAIN'] ??
+      _buildOptions?.toolchain.name ??
+      'stable';
 
   /// Returns the path of directory containing build artifacts.
   Future<String> build() async {


### PR DESCRIPTION
Hi, I added a line to read rustup toolchain version from shell environment “RUSTUP_TOOLCHAIN”, it allows user to use an installed or speficied toolchain, rather than force use 'stable'.

ps. The environment name from [the rustup book](https://rust-lang.github.io/rustup/overrides.html)

thx your work!