### PR TITLE
fix: replace project.exec with ExecOperations for Gradle 9 compability

### DIFF
--- a/cargokit/gradle/plugin.gradle
+++ b/cargokit/gradle/plugin.gradle
@@ -2,7 +2,9 @@
 /// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
 
 import java.nio.file.Paths
+import javax.inject.Inject
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
 
 CargoKitPlugin.file = buildscript.sourceFile
 
@@ -14,6 +16,9 @@ class CargoKitExtension {
 }
 
 abstract class CargoKitBuildTask extends DefaultTask {
+
+    @Inject
+    abstract ExecOperations getExecOperations()
 
     @Input
     String buildMode
@@ -60,12 +65,12 @@ abstract class CargoKitBuildTask extends DefaultTask {
         def rootProjectDir = project.rootProject.projectDir
 
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-            project.exec {
+          execOperations.exec {
                 commandLine 'chmod', '+x', path
             }
         }
 
-        project.exec {
+        execOperations.exec {
             executable path
             args "build-gradle"
             environment "CARGOKIT_ROOT_PROJECT_DIR", rootProjectDir


### PR DESCRIPTION
Newer flutter projects use Gradle 9 which removed Project.exec, causing build failures with:
`> Could not find method exec() for arguments ..`

ported from [flutter_rust_bridge](https://github.com/fzyzcjy/flutter_rust_bridge/commit/cfd1847cbfc57562f2ccb7f5ad9cb1e7b34c231a).